### PR TITLE
Fix issues caused by moving a method

### DIFF
--- a/src/Synapse/SocialLogin/ServiceProvider.php
+++ b/src/Synapse/SocialLogin/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Synapse\SocialLogin;
 
+use OAuth\ServiceFactory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -26,6 +27,7 @@ class ServiceProvider implements ServiceProviderInterface
             $controller
                 ->setSocialLoginService($app['social-login.service'])
                 ->setConfig($config)
+                ->setServiceFactory(new ServiceFactory())
                 ->setSession($app['session']);
 
             return $controller;

--- a/src/Synapse/SocialLogin/SocialLoginService.php
+++ b/src/Synapse/SocialLogin/SocialLoginService.php
@@ -197,35 +197,4 @@ class SocialLoginService
         $this->userService = $service;
         return $this;
     }
-
-    /**
-     * Get a provider service given a provider name
-     *
-     * @param  string $provider
-     * @return OAuth\Common\Service\ServiceInterface
-     */
-    public function getServiceByProvider($provider)
-    {
-        $redirect = $this->url($this->config[$provider]['callback_route'], array(
-            'provider' => $provider,
-        ));
-
-        $serviceName = $this->serviceMap[$provider];
-        $storage     = new SessionStorage(false);
-        $credentials = new ConsumerCredentials(
-            $this->config[$provider]['key'],
-            $this->config[$provider]['secret'],
-            $redirect
-        );
-
-        $serviceFactory = new ServiceFactory;
-        $service = $serviceFactory->createService(
-            $serviceName,
-            $credentials,
-            $storage,
-            $this->config[$provider]['scope']
-        );
-
-        return $service;
-    }
 }


### PR DESCRIPTION
Fix issues caused by moving getServiceByProvider from SocialLoginController to SocialLoginService without taking into account the method's use of $this.
