### PR TITLE
Remove Foreign Key Checks on Upgrade Drop Tables

### DIFF
--- a/src/Synapse/Command/Upgrade/Run.php
+++ b/src/Synapse/Command/Upgrade/Run.php
@@ -203,12 +203,24 @@ class Run extends AbstractUpgradeCommand
     {
         $tables = $this->db->query('SHOW TABLES', DbAdapter::QUERY_MODE_EXECUTE);
 
+        // Disable foreign key checks -- we are wiping the database on purpose
+        $this->db->query(
+            'SET FOREIGN_KEY_CHECKS = 0',
+            DbAdapter::QUERY_MODE_EXECUTE
+        );
+
         foreach ($tables as $table) {
             $this->db->query(
                 'DROP TABLE '.reset($table),
                 DbAdapter::QUERY_MODE_EXECUTE
             );
         }
+
+        // Re-enable foreign key checks
+        $this->db->query(
+            'SET FOREIGN_KEY_CHECKS = 1',
+            DbAdapter::QUERY_MODE_EXECUTE
+        );
     }
 
     /**


### PR DESCRIPTION
## Remove Foreign Key Checks on Upgrade Drop Tables
### Acceptance Criteria
1. When the `upgrade:run --drop-tables` command is used, disable foreign key checks before dropping tables so that foreign key constraints will not cause the drop table commands to fail.
