### PR TITLE
Helper Method to transform Entity Array into Nested Array

### DIFF
--- a/src/Synapse/Controller/AbstractRestController.php
+++ b/src/Synapse/Controller/AbstractRestController.php
@@ -15,6 +15,11 @@ use Synapse\Rest\Exception\MethodNotImplementedException;
  */
 abstract class AbstractRestController extends AbstractController
 {
+    /**
+     * Request body content decoded from JSON
+     *
+     * @var mixed
+     */
     protected $content;
 
     /**
@@ -51,5 +56,22 @@ abstract class AbstractRestController extends AbstractController
         } else {
             throw new RuntimeException('Unhandled response type from controller');
         }
+    }
+
+    /**
+     * Transform an array of AbstractEntities into an array of arrays representing the entities
+     *
+     * @param  array  $entities Array of AbstractEntity objects
+     * @return array            Array of arrays
+     */
+    protected function nestedArrayFromEntities(array $entities)
+    {
+        $results = [];
+
+        foreach ($entities as $entity) {
+            $results[] = $entity->getArrayCopy();
+        }
+
+        return $results;
     }
 }


### PR DESCRIPTION
## Helper Method to transform Entity Array into Nested Array

It is a common use case in REST controllers to perform a `foreach` in order to turn an array of `AbstractEntity` objects into a nested array, for the response body. It would be helpful to have a helper method in the `AbstractRestController` so that this code does not need to be repeated in many places.
