### PR TITLE
Allow more WHERE options than just equality operators

### DIFF
--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -123,8 +123,7 @@ trait FinderTrait
      */
     protected function addWheres($query, $wheres)
     {
-        foreach ($wheres as $key => $where)
-        {
+        foreach ($wheres as $key => $where) {
             if (is_array($where) && count($where) === 3) {
                 $operator = $where[1];
 
@@ -181,7 +180,7 @@ trait FinderTrait
                 }
 
                 $query->where($predicate);
-            } else if (is_string($key) && is_string($where)){
+            } elseif (is_string($key) && is_string($where)) {
                 $query->where([$key => $where]);
             } else {
                 throw new InvalidArgumentException('Invalid WHERE requirement');


### PR DESCRIPTION
## Allow more WHERE options than just equality operators
### Acceptance Criteria
1. Can still pass in ['column' => 'value'] to findBy and findAllBy to mean 'WHERE column = value'.
2. Can also pass in ['column', 'operator', 'value'].
3. Operator can be =, !=, >, <, >=, <=, LIKE, or NOT LIKE.
### Tasks
- None
### Additional Notes
- None
