### PR TITLE
Add method to abstract mapper where JOINs can be performed

### DIFF
--- a/src/Synapse/Mapper/AbstractMapper.php
+++ b/src/Synapse/Mapper/AbstractMapper.php
@@ -153,5 +153,6 @@ abstract class AbstractMapper
     protected function addJoins($query, $wheres)
     {
         // Override if joins are required
+        return $wheres;
     }
 }

--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -26,7 +26,7 @@ trait FinderTrait
     {
         $query = $this->sql()->select();
 
-        $this->addJoins($query, $wheres);
+        $wheres = $this->addJoins($query, $wheres);
 
         $this->addWheres($query, $wheres);
 
@@ -63,7 +63,7 @@ trait FinderTrait
     {
         $query = $this->sql()->select();
 
-        $this->addJoins($query, $wheres);
+        $wheres = $this->addJoins($query, $wheres);
 
         $this->addWheres($query, $wheres);
 


### PR DESCRIPTION
## Add method to abstract mapper where JOINs can be performed.
### Tasks
- addJoins accepts the query object and an array of where conditions.
- addJoins returns the fields array updated with fully qualified names.
### Additional Notes
- None
