### PR TITLE
Use Consistent Method Naming in AbstractController

### DIFF
--- a/src/Synapse/Controller/AbstractController.php
+++ b/src/Synapse/Controller/AbstractController.php
@@ -37,7 +37,7 @@ abstract class AbstractController implements UrlGeneratorAwareInterface, LoggerA
      * @param  string  $content Response content
      * @return Response
      */
-    protected function getSimpleResponse($code = 500, $content = 'Unknown error')
+    protected function createSimpleResponse($code = 500, $content = 'Unknown error')
     {
         $response = new Response;
         $response->setStatusCode($code)
@@ -53,7 +53,7 @@ abstract class AbstractController implements UrlGeneratorAwareInterface, LoggerA
      * @param  array $data  Response data
      * @return JsonResponse
      */
-    protected function getJsonResponse($code, $data)
+    protected function createJsonResponse($code, $data)
     {
         $response = new JsonResponse;
         $response->setStatusCode($code)

--- a/src/Synapse/Controller/AbstractRestController.php
+++ b/src/Synapse/Controller/AbstractRestController.php
@@ -44,7 +44,7 @@ abstract class AbstractRestController extends AbstractController
         $this->content = json_decode($request->getContent(), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            return $this->getSimpleResponse(400, 'Could not parse json body');
+            return $this->createSimpleResponse(400, 'Could not parse json body');
         }
 
         $result = $this->{$method}($request);

--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -89,7 +89,7 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
         }
 
         if (! $correctPassword) {
-            return $this->getSimpleResponse(422, 'Invalid credentials');
+            return $this->createSimpleResponse(422, 'Invalid credentials');
         }
 
         // Automatically authorize the user

--- a/src/Synapse/User/ResetPasswordController.php
+++ b/src/Synapse/User/ResetPasswordController.php
@@ -87,7 +87,7 @@ class ResetPasswordController extends AbstractRestController
 
         $this->emailService->enqueueSendEmailJob($email);
 
-        return $this->getSimpleResponse(204, '');
+        return $this->createSimpleResponse(204, '');
     }
 
     /**
@@ -107,24 +107,24 @@ class ResetPasswordController extends AbstractRestController
         ]);
 
         if (! $token) {
-            return $this->getSimpleResponse(404, 'Token not found');
+            return $this->createNotFoundResponse();
         }
 
         if ($token->getExpires() < time()) {
-            return $this->getSimpleResponse(404, 'Token not found');
+            return $this->createNotFoundResponse();
         }
 
         $user = $this->userService->findById($token->getUserId());
 
         if (! $user) {
-            return $this->getSimpleResponse(404, 'User not found');
+            return $this->createNotFoundResponse();
         }
 
         $password = Arr::get($this->content, 'password');
 
         // Ensure user input is valid
         if (! $password) {
-            return $this->getSimpleResponse(422, 'Password cannot be empty');
+            return $this->createSimpleResponse(422, 'Password cannot be empty');
         }
 
         $this->userService->resetPassword($user, $password);

--- a/src/Synapse/User/UserController.php
+++ b/src/Synapse/User/UserController.php
@@ -34,7 +34,7 @@ class UserController extends AbstractRestController implements SecurityAwareInte
             ->findById($id);
 
         if (! $user) {
-            return $this->getSimpleResponse(404, 'User not found');
+            return $this->createNotFoundResponse();
         }
 
         return $this->userArrayWithoutPassword($user);
@@ -51,7 +51,7 @@ class UserController extends AbstractRestController implements SecurityAwareInte
         $user = $this->content;
 
         if (! isset($user['email'], $user['password'])) {
-            return $this->getSimpleResponse(422, 'Missing required field');
+            return $this->createSimpleResponse(422, 'Missing required field');
         }
 
         try {
@@ -61,15 +61,14 @@ class UserController extends AbstractRestController implements SecurityAwareInte
                 UserService::EMAIL_NOT_UNIQUE => 409,
             ];
 
-            return $this->getSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
+            return $this->createSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
         }
 
         $newUser = $this->userArrayWithoutPassword($newUser);
 
         $newUser['_href'] = $this->url('user-entity', array('id' => $newUser['id']));
 
-        $response = $this->getSimpleResponse(201, json_encode($newUser));
-        return $response;
+        return $this->createJsonResponse(201, $newUser);
     }
 
     /**
@@ -84,7 +83,7 @@ class UserController extends AbstractRestController implements SecurityAwareInte
 
         // Ensure the user in question is logged in
         if ($request->attributes->get('id') !== $user->getId()) {
-            return $this->getSimpleResponse(403, 'Access denied');
+            return $this->createSimpleResponse(403, 'Access denied');
         }
 
         try {
@@ -95,7 +94,7 @@ class UserController extends AbstractRestController implements SecurityAwareInte
                 UserService::FIELD_CANNOT_BE_EMPTY     => 422,
             ];
 
-            return $this->getSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
+            return $this->createSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
         }
 
         return $this->userArrayWithoutPassword($user);

--- a/src/Synapse/User/VerifyRegistrationController.php
+++ b/src/Synapse/User/VerifyRegistrationController.php
@@ -34,7 +34,7 @@ class VerifyRegistrationController extends AbstractRestController implements Sec
         $token = Arr::get($this->content, 'token');
 
         if (! $token) {
-            return $this->getSimpleResponse(422, 'Token not specified.');
+            return $this->createSimpleResponse(422, 'Token not specified.');
         }
 
         $conditions = [
@@ -46,7 +46,7 @@ class VerifyRegistrationController extends AbstractRestController implements Sec
         $token = $this->userService->findTokenBy($conditions);
 
         if (! $token) {
-            return $this->getSimpleResponse(404, 'Token not found.');
+            return $this->createNotFoundResponse();
         }
 
         try {
@@ -58,7 +58,7 @@ class VerifyRegistrationController extends AbstractRestController implements Sec
                 UserService::TOKEN_NOT_FOUND      => 404,
             ];
 
-            return $this->getSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
+            return $this->createSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
         }
 
         $user = $user->getArrayCopy();


### PR DESCRIPTION
## Use Consistent Method Naming in AbstractController
### Acceptance Criteria
1. `AbstractController::getSimpleResponse` is called `createSimpleResponse` to match `createNotFoundResponse`.
2. `AbstractController::getJsonResponse` is called `createJsonResponse` to match `createNotFoundResponse`.
3. Anywhere those helper methods are used, they are renamed.
### Tasks
- None
### Additional Notes
- None
