### PR TITLE
Make install script injectable in Command\Upgrade\Run

### DIFF
--- a/src/Synapse/Command/Upgrade/Run.php
+++ b/src/Synapse/Command/Upgrade/Run.php
@@ -170,7 +170,7 @@ class Run extends AbstractUpgradeCommand
             }
 
             $this->install(
-                $this->getInstallScript(),
+                $installScript,
                 $output
             );
 


### PR DESCRIPTION
## Make install script injectable in Command\Upgrade\Run.

I ran into an issue with the puppies API where I needed to access a config file from the install script.  This change will make it so I can inject an install script that has the config object injected into it.
### Acceptance Criteria
1. If install script is injected, it will be used.
2. If no install script is injected, the class at the expected install script path will be instantiated with no arguments.
### Tasks
- None
### Additional Notes
- None
