### PR TITLE
Do not set app version after install script is run

### DIFF
--- a/src/Synapse/Command/Upgrade/Run.php
+++ b/src/Synapse/Command/Upgrade/Run.php
@@ -173,11 +173,6 @@ class Run extends AbstractUpgradeCommand
                 $installScript,
                 $output
             );
-
-            $this->recordUpgrade($this->appVersion);
-
-            // Refresh database version
-            $databaseVersion = $this->currentDatabaseVersion();
         }
 
         // Run all migrations


### PR DESCRIPTION
## Do not set app version after install script is run
### Description

In the `Upgrade:Run` console command, the current app codebase version is being written to the database after the install script (before checking if there is an upgrade to run.)

When installing a fresh version of the app (`Upgrade:Run --drop-tables`) when the codebase is already at the version of the first upgrade, the upgrade will not run because of the faulty logic:
- Install script runs
- Set database version to current version (0.0.1)
- Check to see if there is an upgrade to run.
  - 0.0.1 upgrade exists
  - Database is already at 0.0.1
  - No upgrade to run
