### PR TITLE
Helper Methods for Validators

### DIFF
--- a/src/Synapse/Controller/AbstractController.php
+++ b/src/Synapse/Controller/AbstractController.php
@@ -62,9 +62,9 @@ abstract class AbstractController implements UrlGeneratorAwareInterface, LoggerA
         return $response;
     }
 
-    protected function constraintViolationArray(ConstraintViolationListInterface $violationList)
+    protected function createConstraintViolationResponse(ConstraintViolationListInterface $violationList)
     {
-        $results = [];
+        $errors = [];
 
         foreach ($violationList as $violation) {
             $field = $violation->getPropertyPath();
@@ -74,9 +74,12 @@ abstract class AbstractController implements UrlGeneratorAwareInterface, LoggerA
                 $field
             );
 
-            $results[$field][] = $violation->getMessage();
+            $errors[$field][] = $violation->getMessage();
         }
 
-        return $results;
+        return $this->createJsonResponse(
+            422,
+            ['errors' => $errors]
+        );
     }
 }

--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -4,6 +4,8 @@ namespace Synapse\TestHelper;
 
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolation;
 use Synapse\Stdlib\Arr;
 use Synapse\User\UserEntity;
 use stdClass;
@@ -80,5 +82,18 @@ abstract class ControllerTestCase extends PHPUnit_Framework_TestCase
         ]);
 
         return $user;
+    }
+
+    public function createNonEmptyConstraintViolationList()
+    {
+        $builder = $this->getMockBuilder('Symfony\Component\Validator\ConstraintViolation')
+            ->disableOriginalConstructor();
+
+        $violations = [
+            $builder->getMock(),
+            $builder->getMock(),
+        ];
+
+        return new ConstraintViolationList($violations);
     }
 }


### PR DESCRIPTION
## Helper Methods for Validators
### Acceptance Criteria
1. `createNonEmptyConstraintViolationList` exists in `ControllerTestCase` and returns a ConstraintViolationList with ConstraintViolation mocks.
2. `createConstraintViolationResponse` exists in `AbstractController`. It takes a ConstraintViolationList and returns a JsonResponse with this format: `['errors' => $errors]` where `$errors` is the output of the ConstraintViolationList's getArrayCopy method.
### Tasks
- None
### Additional Notes
- `createNonEmptyConstraintViolationList` will be used to test controllers that use validators.
