### PR TITLE
Add pre-where hook method to FinderTrait

### DIFF
--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -186,9 +186,15 @@ trait FinderTrait
 
         // Get total results
         $queryClone = clone $query;
-        $queryClone->columns(['count' => new Expression('COUNT(*)')]);
+
+        $columns = $queryClone->getRawState()[Select::COLUMNS];
+        $columns['count'] = new Expression('COUNT(*)');
+
+        $queryClone->columns($columns);
+
         $statement = $this->sql()->prepareStatementForSqlObject($queryClone);
         $result = $statement->execute()->current();
+
         $resultCount = $result['count'];
         $pageCount = ceil($resultCount / $resultsPerPage);
 


### PR DESCRIPTION
## Add pre-where hook method to FinderTrait

A mapper might have special logic it needs to perform before adding the standard WHERE clauses.  This method will be the place for that.
### Acceptance Criteria
1. None
### Tasks
- None
### Additional Notes
- None
