### PR TITLE
Make Array Validator Strict

### DIFF
--- a/src/Synapse/Validator/AbstractArrayValidator.php
+++ b/src/Synapse/Validator/AbstractArrayValidator.php
@@ -43,18 +43,7 @@ abstract class AbstractArrayValidator
      */
     public function validate(array $values)
     {
-        $optionalConstraints = array_intersect_key(
-            $this->getOptionalConstraints(),
-            $values
-        );
-
-        $constraints = array_merge(
-            $optionalConstraints,
-            $this->getConstraints()
-        );
-
-        // Remove any fields that are not constrained
-        $values = array_intersect_key($values, $constraints);
+        $constraints = $this->getConstraints();
 
         $arrayConstraint = new Assert\Collection($constraints);
 
@@ -68,25 +57,25 @@ abstract class AbstractArrayValidator
      * Return an array of validation rules for use with Symfony Validator
      *
      * @link http://silex.sensiolabs.org/doc/providers/validator.html#validating-associative-arrays
+     *
+     * In order to make a field optional, simply use the Optional constraint.
+     *
+     * If a field should be optional, but should have constraints if it exists,
+     * simply provide the constraints to the constructor of the Optional constraint as such:
+     *
+     *     'first_name' => new Assert\Optional(new Assert\NotBlank())
+     *
+     * To add multiple constraints, provide an array:
+     *
+     *     'first_name' => new Assert\Optional([
+     *         new Assert\NotBlank(),
+     *         new Assert\NotNull(),
+     *     ])
+     *
+     * @link http://symfony.com/doc/current/reference/constraints/Collection.html#required-and-optional-field-constraints
+     *
      * @return array Associative array of Symfony\Component\Validator\Constraints\*
      *               objects sharing keys from the array being validated.
      */
-    protected function getConstraints()
-    {
-        return [];
-    }
-
-    /**
-     * Return an array of validation rules for optional fields
-     *
-     * This is necessary because there is no concept of optional fields in Symfony Validation
-     *
-     * @link http://silex.sensiolabs.org/doc/providers/validator.html#validating-associative-arrays
-     * @return array Associative array of Symfony\Component\Validator\Constraints\*
-     *               objects sharing keys from the array being validated.
-     */
-    protected function getOptionalConstraints()
-    {
-        return [];
-    }
+    abstract protected function getConstraints();
 }


### PR DESCRIPTION
## Make Array Validator Strict
### Acceptance Criteria
1. `AbstractArrayValidator::validate()` does not explicitly try to allow fields to pass through which are not defined in `getConstraints`.
2. `AbstractArrayValidator::getOptionalConstraints` no longer exists; constraints in `getConstraints` must be wrapped in the `Optional` constraint instead.
### Additional Notes

In #38, the `AbstractArrayValidator` was made to allow any fields to pass through that were not defined in `getConstraints`. The purpose: to create a way for "optional" fields to exists. This conflicts with the `getOptionalConstraints` method. Neither are necessary; children of `AbstractArrayValidator` can simply use the `Optional` constraint on a field.
