### PR TITLE
Refresh app version before running upgrades

### DIFF
--- a/src/Synapse/Command/Upgrade/Run.php
+++ b/src/Synapse/Command/Upgrade/Run.php
@@ -173,6 +173,9 @@ class Run extends AbstractUpgradeCommand
                 $installScript,
                 $output
             );
+
+            // Refresh database version
+            $databaseVersion = $this->currentDatabaseVersion();
         }
 
         // Run all migrations


### PR DESCRIPTION
## Description

Related to #33. The app version needs to be refreshed after install, but the version should not be written to the database.
