### PR TITLE
Pass Options to Methods in Mappers

### DIFF
--- a/src/Synapse/Mapper/AbstractMapper.php
+++ b/src/Synapse/Mapper/AbstractMapper.php
@@ -153,10 +153,11 @@ abstract class AbstractMapper implements LoggerAwareInterface
      *
      * @param  PreparableSqlInterface $query
      * @param  array                  $wheres
+     * @param  array                  $options
      * @return array                          Updated $wheres that may include
      *                                        fully qualified names.
      */
-    protected function addJoins($query, $wheres)
+    protected function addJoins($query, $wheres, $options = [])
     {
         // Override if joins are required
         return $wheres;

--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -86,9 +86,9 @@ trait FinderTrait
     {
         $query = $this->sql()->select();
 
-        $wheres = $this->addJoins($query, $wheres);
+        $wheres = $this->addJoins($query, $wheres, $options);
 
-        $this->addWheres($query, $wheres);
+        $this->addWheres($query, $wheres, $options);
 
         $page = Arr::get($options, 'page');
 
@@ -227,10 +227,11 @@ trait FinderTrait
      * @param array              $wheres An array of where conditions in the format:
      *                                   ['column' => 'value'] or
      *                                   ['column', 'operator', 'value']
+     * @param  array             $options
      * @return PreparableSqlInterface
      * @throws InvalidArgumentException  If a WHERE requirement is in an unsupported format.
      */
-    protected function addWheres(PreparableSqlInterface $query, array $wheres)
+    protected function addWheres(PreparableSqlInterface $query, array $wheres, array $options = [])
     {
         foreach ($wheres as $key => $where) {
             if (is_array($where) && count($where) === 3) {


### PR DESCRIPTION
## Pass Options to Methods in Mappers so children can access options in overridden methods
### Acceptance Criteria
1. Mappers pass `$options` to `addWheres` in the FinderTrait and `addJoins` in the AbstractMapper.
### Tasks
- None
### Additional Notes
- None
