### PR TITLE
Handle any ArraySerializableInterface object returned by REST method

### DIFF
--- a/src/Synapse/Controller/AbstractRestController.php
+++ b/src/Synapse/Controller/AbstractRestController.php
@@ -50,12 +50,12 @@ abstract class AbstractRestController extends AbstractController
 
         $result = $this->{$method}($request);
 
-        if ($result instanceof Response) {
-            return $result;
+        if ($result instanceof ArraySerializableInterface) {
+            return new JsonResponse($result->getArrayCopy());
         } elseif (is_array($result)) {
             return new JsonResponse($result);
-        } elseif ($result instanceof ArraySerializableInterface) {
-            return new JsonResponse($result->getArrayCopy());
+        } elseif ($result instanceof Response) {
+            return $result;
         } else {
             throw new RuntimeException(
                 sprintf(


### PR DESCRIPTION
## Handle any ArraySerializableInterface object returned by REST method

This will make it more straightforward to write tests for rest controllers, since return values can be compared by reference instead of comparing the result of getArrayCopy.
### Tasks
- Edit AbstractRestController::execute() to handle a returned ArraySerializableInterface.
### Additional Notes
- None
