### PR TITLE
Abstract Rest Controller Does Not Return 400 If Request Body Malformed

### DIFF
--- a/src/Synapse/Controller/AbstractRestController.php
+++ b/src/Synapse/Controller/AbstractRestController.php
@@ -42,11 +42,11 @@ abstract class AbstractRestController extends AbstractController
             );
         }
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        try {
+            $result = $this->{$method}($request);
+        } catch (BadRequestException $e) {
             return $this->createSimpleResponse(400, 'Could not parse json body');
         }
-
-        $result = $this->{$method}($request);
 
         if ($result instanceof ArraySerializableInterface) {
             return new JsonResponse($result->getArrayCopy());
@@ -72,6 +72,12 @@ abstract class AbstractRestController extends AbstractController
      */
     protected function getContentAsArray(Request $request)
     {
-        return json_decode($request->getContent(), true);
+        $content = json_decode($request->getContent(), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new BadRequestException();
+        }
+
+        return $content;
     }
 }

--- a/src/Synapse/Controller/BadRequestException.php
+++ b/src/Synapse/Controller/BadRequestException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Synapse\Controller;
+
+class BadRequestException extends \RuntimeException
+{
+}

--- a/tests/Test/Synapse/Controller/AbstractRestControllerTest.php
+++ b/tests/Test/Synapse/Controller/AbstractRestControllerTest.php
@@ -47,4 +47,17 @@ class AbstractRestControllerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
         $this->assertEquals('{"test":"test"}', (string) $response->getContent());
     }
+
+    public function testGetContentAsArrayThrowsExceptionWhichExecuteCatchesAndReturns400IfContentInvalid()
+    {
+        $invalidJson = 'This is not JSON.';
+
+        $request = new Request([], [], [], [], [], [], $invalidJson);
+
+        $request->setMethod('delete');
+
+        $response = $this->controller->execute($request);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
 }

--- a/tests/Test/Synapse/Controller/RestController.php
+++ b/tests/Test/Synapse/Controller/RestController.php
@@ -2,6 +2,7 @@
 
 namespace Test\Synapse\Controller;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Synapse\Controller\AbstractRestController;
 use PHPUnit_Framework_TestCase;
@@ -17,5 +18,12 @@ class RestController extends AbstractRestController
     public function put()
     {
         return ['test' => 'test'];
+    }
+
+    public function delete(Request $request)
+    {
+        $content = $this->getContentAsArray($request);
+
+        return $content;
     }
 }


### PR DESCRIPTION
## Abstract Rest Controller Does Not Return 400 If Request Body Malformed

Related to #60. The logic which checks for json_decode errors was not moved correctly.
