### PR TITLE
AbstractRestController::getContentAsArray returns null if JSON is null

### DIFF
--- a/src/Synapse/Controller/AbstractRestController.php
+++ b/src/Synapse/Controller/AbstractRestController.php
@@ -78,6 +78,10 @@ abstract class AbstractRestController extends AbstractController
             throw new BadRequestException();
         }
 
+        if ($content === null) {
+            return [];
+        }
+
         return $content;
     }
 }


### PR DESCRIPTION
## Description

AbstractRestController::getContentAsArray returns null if JSON is null. It should return an empty array.
