### PR TITLE
Abstract Entity Interface

### DIFF
--- a/src/Synapse/Entity/AbstractEntity.php
+++ b/src/Synapse/Entity/AbstractEntity.php
@@ -10,7 +10,7 @@ use Synapse\Stdlib\DataObject;
 /**
  * An abstract class for representing database records as entity objects
  */
-abstract class AbstractEntity extends DataObject implements LoggerAwareInterface
+abstract class AbstractEntity extends DataObject implements AbstractEntityInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 

--- a/src/Synapse/Entity/AbstractEntityInterface.php
+++ b/src/Synapse/Entity/AbstractEntityInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Synapse\Entity;
+
+use Zend\Stdlib\ArraySerializableInterface;
+
+interface AbstractEntityInterface extends ArraySerializableInterface
+{
+    /**
+     * Get all columns of this entity that correspond to database columns
+     *
+     * @return array
+     */
+    public function getColumns();
+
+    /**
+     * Get values which are to be saved to the database
+     *
+     * Useful if as_array is overridden to return values not
+     * saved to the database.
+     *
+     * @return array
+     */
+    public function getDbValues();
+
+    /**
+     * Determine if this entity is new (not yet persisted) by checking for existence of an ID
+     *
+     * @return boolean
+     */
+    public function isNew();
+}


### PR DESCRIPTION
## Abstract Entity Interface
### Acceptance Criteria
1. Interface for AbstractEntity exists so that child interfaces can extend it.
