### PR TITLE
ControllerTestCase::createJsonRequest sets content as an empty string if content is an empty array

### DIFF
--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -23,7 +23,7 @@ abstract class ControllerTestCase extends PHPUnit_Framework_TestCase
             [],
             [],
             [],
-            Arr::get($params, 'content') ? json_encode($params['content']) : ''
+            Arr::get($params, 'content') !== null ? json_encode($params['content']) : ''
         );
         $this->request->setMethod($method);
         $this->request->headers->set('CONTENT_TYPE', 'application/json');


### PR DESCRIPTION
## ControllerTestCase::createJsonRequest sets content as an empty string if content is an empty array

`$this->createJsonRequest('post', ['content' => []])` should create a request whose content is '[]', but instead it creates one whose content is ''.
