### PR TITLE
Make service definitions more succinct

### DIFF
--- a/src/Synapse/Command/CommandServiceProvider.php
+++ b/src/Synapse/Command/CommandServiceProvider.php
@@ -17,7 +17,7 @@ class CommandServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['console'] = $app->share(function () use ($app) {
+        $app['console'] = $app->share(function ($app) {
             return new ConsoleApplication;
         });
     }

--- a/src/Synapse/Config/ServiceProvider.php
+++ b/src/Synapse/Config/ServiceProvider.php
@@ -15,7 +15,7 @@ class ServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['config'] = $app->share(function () use ($app) {
+        $app['config'] = $app->share(function ($app) {
             $config = new Config();
 
             foreach ($app['config_dirs'] as $directory) {

--- a/src/Synapse/Db/DbServiceProvider.php
+++ b/src/Synapse/Db/DbServiceProvider.php
@@ -19,7 +19,7 @@ class DbServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['db'] = $app->share(function () use ($app) {
+        $app['db'] = $app->share(function ($app) {
             return new Adapter($app['config']->load('db'));
         });
     }

--- a/src/Synapse/Install/InstallServiceProvider.php
+++ b/src/Synapse/Install/InstallServiceProvider.php
@@ -17,7 +17,7 @@ class InstallServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['install.generate'] = $app->share(function () use ($app) {
+        $app['install.generate'] = $app->share(function ($app) {
             $command = new \Synapse\Command\Install\Generate;
 
             $command->setDbConfig($app['config']->load('db'));
@@ -26,7 +26,7 @@ class InstallServiceProvider implements ServiceProviderInterface
             return $command;
         });
 
-        $app['install.run'] = $app->share(function () use ($app) {
+        $app['install.run'] = $app->share(function ($app) {
             $command = new \Synapse\Command\Install\Run;
 
             $command->setDatabaseAdapter($app['db']);

--- a/src/Synapse/Log/LogServiceProvider.php
+++ b/src/Synapse/Log/LogServiceProvider.php
@@ -63,7 +63,7 @@ class LogServiceProvider implements ServiceProviderInterface
             $handlers[] = $this->rollbarHandler($app['environment']);
         }
 
-        $app['log'] = $app->share(function () use ($app, $handlers) {
+        $app['log'] = $app->share(function ($app) use ($handlers) {
             return new Logger('main', $handlers);
         });
 

--- a/src/Synapse/Migration/MigrationServiceProvider.php
+++ b/src/Synapse/Migration/MigrationServiceProvider.php
@@ -17,7 +17,7 @@ class MigrationServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['migrations.create'] = $app->share(function () use ($app) {
+        $app['migrations.create'] = $app->share(function ($app) {
             $command = new \Synapse\Command\Migrations\Create(
                 new \Synapse\View\Migration\Create($app['mustache'])
             );
@@ -31,7 +31,7 @@ class MigrationServiceProvider implements ServiceProviderInterface
             return $command;
         });
 
-        $app['migrations.run'] = $app->share(function () use ($app) {
+        $app['migrations.run'] = $app->share(function ($app) {
             $command = new \Synapse\Command\Migrations\Run;
 
             $command->setDatabaseAdapter($app['db']);

--- a/src/Synapse/OAuth2/SecurityServiceProvider.php
+++ b/src/Synapse/OAuth2/SecurityServiceProvider.php
@@ -16,7 +16,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['security.authentication_listener.factory.oauth'] = $app->protect(function ($name, $options) use ($app) {
-            $app['security.authentication_provider.'.$name.'.oauth'] = $app->share(function () use ($app) {
+            $app['security.authentication_provider.'.$name.'.oauth'] = $app->share(function ($app) {
                 return new OAuth2Provider(
                     $app['user.mapper'],
                     $app['role.service'],
@@ -24,7 +24,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 );
             });
 
-            $app['security.authentication_listener.'.$name.'.oauth'] = $app->share(function () use ($app) {
+            $app['security.authentication_listener.'.$name.'.oauth'] = $app->share(function ($app) {
                 return new OAuth2Listener($app['security'], $app['security.authentication_manager']);
             });
 

--- a/src/Synapse/OAuth2/ServerServiceProvider.php
+++ b/src/Synapse/OAuth2/ServerServiceProvider.php
@@ -25,7 +25,7 @@ class ServerServiceProvider implements ServiceProviderInterface
      */
     public function setup(Application $app)
     {
-        $app['oauth.storage'] = $app->share(function () use ($app) {
+        $app['oauth.storage'] = $app->share(function ($app) {
             // Create the storage object
             $storage = new OAuth2ZendDb($app['db']);
             $storage->setUserMapper($app['user.mapper']);
@@ -33,7 +33,7 @@ class ServerServiceProvider implements ServiceProviderInterface
             return $storage;
         });
 
-        $app['oauth_server'] = $app->share(function () use ($app) {
+        $app['oauth_server'] = $app->share(function ($app) {
             $storage = $app['oauth.storage'];
 
             $grantTypes = [
@@ -59,7 +59,7 @@ class ServerServiceProvider implements ServiceProviderInterface
             );
         });
 
-        $app['oauth.controller'] = $app->share(function () use ($app) {
+        $app['oauth.controller'] = $app->share(function ($app) {
             return new OAuthController(
                 $app['oauth_server'],
                 $app['user.service'],
@@ -70,11 +70,11 @@ class ServerServiceProvider implements ServiceProviderInterface
             );
         });
 
-        $app['oauth-access-token.mapper'] = $app->share(function () use ($app) {
+        $app['oauth-access-token.mapper'] = $app->share(function ($app) {
             return new AccessTokenMapper($app['db'], new AccessTokenEntity);
         });
 
-        $app['oauth-refresh-token.mapper'] = $app->share(function () use ($app) {
+        $app['oauth-refresh-token.mapper'] = $app->share(function ($app) {
             return new RefreshTokenMapper($app['db'], new RefreshTokenEntity);
         });
     }

--- a/src/Synapse/Resque/ResqueServiceProvider.php
+++ b/src/Synapse/Resque/ResqueServiceProvider.php
@@ -18,11 +18,11 @@ class ResqueServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['resque'] = $app->share(function () use ($app) {
+        $app['resque'] = $app->share(function ($app) {
             return new ResqueService($app['config']->load('resque'));
         });
 
-        $app['resque.command'] = $app->share(function () use ($app) {
+        $app['resque.command'] = $app->share(function ($app) {
             $command = new ResqueCommand;
             $command->setResque($app['resque']);
             return $command;

--- a/src/Synapse/SocialLogin/SocialLoginServiceProvider.php
+++ b/src/Synapse/SocialLogin/SocialLoginServiceProvider.php
@@ -21,7 +21,7 @@ class SocialLoginServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['social-login.controller'] = $app->share(function () use ($app) {
+        $app['social-login.controller'] = $app->share(function ($app) {
             $config = $app['config']->load('social-login');
 
             $controller = new SocialLoginController;
@@ -34,11 +34,11 @@ class SocialLoginServiceProvider implements ServiceProviderInterface
             return $controller;
         });
 
-        $app['social-login.mapper'] = $app->share(function () use ($app) {
+        $app['social-login.mapper'] = $app->share(function ($app) {
             return new SocialLoginMapper($app['db'], new SocialLoginEntity);
         });
 
-        $app['social-login.service'] = $app->share(function () use ($app) {
+        $app['social-login.service'] = $app->share(function ($app) {
             $service = new SocialLoginService;
             $service->setUserService($app['user.service'])
                 ->setSocialLoginMapper($app['social-login.mapper'])


### PR DESCRIPTION
## Make service definitions more succinct
### Tasks
- Where a service is defined as `$app->share(function () use ($app) {...`, replace with `$app->share(function ($app) {` since Pimple attempts to inject the app.
### Additional Notes
- It probably only introduces a minuscule amount of overhead, but it's cleaner to read, it's how Silex is built to work, and it provides a better example for projects to follow.
