### PR TITLE
Fix errors when running install:run console command

### DIFF
--- a/src/Synapse/Install/GenerateInstallCommand.php
+++ b/src/Synapse/Install/GenerateInstallCommand.php
@@ -91,7 +91,7 @@ class GenerateInstallCommand implements CommandInterface
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $outputPath = $this->dataPath();
+        $outputPath = DATADIR;
 
         $output->write(['', '  Generating install files...', ''], true);
 
@@ -100,16 +100,6 @@ class GenerateInstallCommand implements CommandInterface
 
         $this->dumpData($outputPath);
         $output->write(['  Exported DB data', ''], true);
-    }
-
-    /**
-     * Return the path to upgrade files based on the upgrade namespace provided
-     *
-     * @return string
-     */
-    public function dataPath()
-    {
-        return APPDIR.'/data/';
     }
 
     /**

--- a/src/Synapse/Install/RunInstallCommand.php
+++ b/src/Synapse/Install/RunInstallCommand.php
@@ -156,7 +156,7 @@ class RunInstallCommand extends AbstractDatabaseCommand
 
         // Run all migrations
         $output->writeln('  Executing new migrations before upgrading');
-        $this->runMigrationsCommand->execute($input, $output);
+        $this->runMigrationsCommand->run($input, $output);
 
         $output->write([sprintf('  Done!', $this->appVersion), ''], true);
     }
@@ -196,7 +196,7 @@ class RunInstallCommand extends AbstractDatabaseCommand
      */
     protected function install(AbstractInstall $installScript, OutputInterface $output)
     {
-        $dataPath = $this->generateInstallCommand->dataPath();
+        $dataPath = DATADIR;
 
         $output->writeln('  Installing App...');
 

--- a/tests/Test/Synapse/Install/GenerateInstallCommandTest.php
+++ b/tests/Test/Synapse/Install/GenerateInstallCommandTest.php
@@ -51,11 +51,6 @@ class GenerateInstallCommandTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($command, $expected);
     }
 
-    public function testDataPath()
-    {
-        $this->assertEquals(APPDIR.'/data/', $this->command->dataPath());
-    }
-
     public function testGetUpgradeNamespace()
     {
         $this->assertEquals('Application\\Upgrades\\', $this->command->getUpgradeNamespace());


### PR DESCRIPTION
# Fix errors when running install:run console command

There is an undefined method error and a 'cannot call protected method' error.
