### PR TITLE
Firewall Listener for Optional OAuth Authentication

### DIFF
--- a/src/Synapse/OAuth2/SecurityServiceProvider.php
+++ b/src/Synapse/OAuth2/SecurityServiceProvider.php
@@ -51,8 +51,8 @@ class SecurityServiceProvider implements ServiceProviderInterface
             });
 
             return [
-                'security.authentication_provider.'.$name.'.oauth',
-                'security.authentication_listener.'.$name.'.oauth',
+                'security.authentication_provider.'.$name.'.oauth-optional',
+                'security.authentication_listener.'.$name.'.oauth-optional',
                 null,
                 'pre_auth'
             ];

--- a/src/Synapse/Security/Firewall/OAuth2OptionalListener.php
+++ b/src/Synapse/Security/Firewall/OAuth2OptionalListener.php
@@ -2,6 +2,10 @@
 
 namespace Synapse\Security\Firewall;
 
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Synapse\Security\Authentication\OAuth2UserToken;
+
 /**
  * Listener which sets the security token on the security context if the user is logged in,
  * but does not forbid access if the user is not logged in.
@@ -15,14 +19,11 @@ class OAuth2OptionalListener extends OAuth2Listener
     {
         $request = $event->getRequest();
 
-        if ($request->getMethod() === 'OPTIONS') {
-            return;
-        }
-
         $regex = '/Bearer (.*)/';
         if (! $request->headers->has('Authorization') ||
             preg_match($regex, $request->headers->get('Authorization'), $matches) !== 1
         ) {
+            $this->securityContext->setToken(new AnonymousToken('', 'anon.', array()));
             return;
         }
 


### PR DESCRIPTION
## Firewall Listener for Optional OAuth Authentication
### Acceptance Criteria
1. `oauth-optional` firewall listener exists which does not block the user if they're logged in, but sets the security context if they are.
