### PR TITLE
SecurityContext mock returns new user instance with every call

### DIFF
--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -87,7 +87,7 @@ abstract class ControllerTestCase extends PHPUnit_Framework_TestCase
     {
         // If not changed from initial value, return default.
         if ($this->loggedInUserEntity === false) {
-            return $this->getDefaultLoggedInUserEntity();
+            $this->loggedInUserEntity = $this->getDefaultLoggedInUserEntity();
         }
 
         return $this->loggedInUserEntity;


### PR DESCRIPTION
## SecurityContext mock returns new user instance with every call

If setLoggedInUserEntity is not called, the SecurityContext mock will return a new UserEntity instance with every call to `getToken()->getUser()`.  It should return the same instance every time.
