### PR TITLE
Update Test Helpers to use traits to set up mock security context and/or a mock db interface

### DIFF
--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Synapse\TestHelper;
 
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -9,8 +10,12 @@ use Synapse\Stdlib\Arr;
 use Synapse\User\UserEntity;
 use stdClass;
 
-abstract class ControllerTestCase extends AbstractSecurityAwareTestCase
+abstract class ControllerTestCase extends PHPUnit_Framework_TestCase
 {
+    use SecurityAwareTestCaseTrait;
+
+    const LOGGED_IN_USER_ID = 42;
+
     public function createJsonRequest($method, array $params = [])
     {
         $this->request = new Request(

--- a/src/Synapse/TestHelper/DbAdapterTestCaseTrait.php
+++ b/src/Synapse/TestHelper/DbAdapterTestCaseTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Synapse\TestHelper;
+
+/**
+ * Use this trait to test classes that require access to the DB adapter
+ */
+trait DbAdapterTestCaseTrait
+{
+    public function setUpMockAdapter()
+    {
+        $this->mockAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockAdapter->expects($this->any())
+            ->method('query')
+            ->will($this->returnCallback(function ($sql, $mode) {
+                $this->sqlStrings[] = $sql;
+
+                if ($mode === 'prepare') {
+                    return $this->getMockStatement();
+                } else {
+                    return $this->getMockResult();
+                }
+            }));
+
+        $this->mockDriver = $this->getMockBuilder('Zend\Db\Adapter\Driver\Mysqli\Mysqli')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockDriver->expects($this->any())
+            ->method('createStatement')
+            ->will($this->returnValue($this->getMockStatement()));
+
+        $this->mockConnection = $this->getMock('Zend\Db\Adapter\Driver\ConnectionInterface');
+
+        $this->mockDriver->expects($this->any())
+            ->method('getConnection')
+            ->will($this->returnValue($this->mockConnection));
+
+        $this->mockConnection->expects($this->any())
+            ->method('getResource')
+            ->will($this->returnValue(
+                $this->getMock('mysqli')
+            ));
+
+        $this->mockAdapter->expects($this->any())
+            ->method('getDriver')
+            ->will($this->returnValue($this->mockDriver));
+
+        $this->mockAdapter->expects($this->any())
+            ->method('getPlatform')
+            ->will($this->returnValue($this->getPlatform()));
+    }
+}

--- a/src/Synapse/TestHelper/SecurityAwareTestCaseTrait.php
+++ b/src/Synapse/TestHelper/SecurityAwareTestCaseTrait.php
@@ -2,17 +2,16 @@
 
 namespace Synapse\TestHelper;
 
-use PHPUnit_Framework_TestCase;
 use Synapse\User\UserEntity;
 use stdClass;
 
 /**
- * Extend this class to create mocks of the security token and context for testing
+ * Use this trait to test classes that require access to the currently logged in user.
+ *
+ * NOTE - this trait requires that constant LOGGED_IN_USER_ID be set in implementing classes.
  */
-abstract class AbstractSecurityAwareTestCase extends PHPUnit_Framework_TestCase
+trait SecurityAwareTestCaseTrait
 {
-    const LOGGED_IN_USER_ID = 42;
-
     /**
      * @var mixed  UserEntity or null to simulate the user not being logged in
      */


### PR DESCRIPTION
### Tasks
- Create two new traits files in the TestHelpFolder, SecurityAwareTestCaseTrait and DbAdapterTestCaseTrait
- Move logic from AbstractSecurityAwareTestCase into SecurityAwareTestCaseTrait
- Update ControllerTestCase and MapperTestCase to use SecurityAwareTestCaseTrait and no longer inherit from AbstractSecurityAwareTestCase
- Remove AbstractSecurityAwareTestCase
- Move logic for setting up the mock db adapter from MapperTestCase into DbAdapterTestCaseTrait
- Update MapperTestCase to use DbAdapterTestCaseTrait
