### PR TITLE
Create 'Transaction' Class

### DIFF
--- a/src/Synapse/Db/Transaction.php
+++ b/src/Synapse/Db/Transaction.php
@@ -12,7 +12,6 @@ class Transaction
     protected $connection;
 
     /**
-     * Set injected objects as properties
      * @param DbAdapter $dbAdapter Query builder object
      */
     public function __construct(DbAdapter $dbAdapter)


### PR DESCRIPTION
## Create a 'Transaction' class, which can be injected into non-mapper classes (e.g., controllers), to grant them the ability to begin, commit and rollback transactions without being exposed to the rest of the dbAdapter.
### Tasks
- Create the 'Transaction' class, which requires a DbAdapter in the constructor
- Add begin, commit, and rollback methods to the Transaction class
