### PR TITLE
Stack trace returned with 500 response should be an array

### DIFF
--- a/src/Synapse/Controller/AbstractRestController.php
+++ b/src/Synapse/Controller/AbstractRestController.php
@@ -110,6 +110,8 @@ abstract class AbstractRestController extends AbstractController
         ];
 
         if ($this->debug) {
+            $responseData['file']   = $exception->getFile();
+            $responseData['line']  = $exception->getLine();
             $responseData['trace'] = $exception->getTrace();
         };
 

--- a/tests/Test/Synapse/Controller/AbstractRestControllerTest.php
+++ b/tests/Test/Synapse/Controller/AbstractRestControllerTest.php
@@ -136,6 +136,8 @@ class AbstractRestControllerTest extends ControllerTestCase
         $content = json_decode($response->getContent(), true);
 
         $this->assertArrayHasKey('trace', $content);
+        $this->assertArrayHasKey('line', $content);
+        $this->assertArrayHasKey('file', $content);
         $this->assertTrue(is_array($content['trace']));
     }
 
@@ -149,6 +151,8 @@ class AbstractRestControllerTest extends ControllerTestCase
         $content = json_decode($response->getContent(), true);
 
         $this->assertArrayNotHasKey('trace', $content);
+        $this->assertArrayNotHasKey('line', $content);
+        $this->assertArrayNotHasKey('file', $content);
     }
 
     public function testRequestThatThrowsExceptionLogsErrorMessageAndStackTraceIfDebugging()


### PR DESCRIPTION
## Stack trace returned with 500 response should be an array

Related to #103.  Since newlines aren't displayed in the stack trace, the trace should be returned as an array, making it more readable.
### Acceptance Criteria
1. None
### Tasks
- None
### Additional Notes
- None
