### PR TITLE
InvalidArgumentException - Identifier "env" is not defined

### DIFF
--- a/src/Synapse/Install/InstallServiceProvider.php
+++ b/src/Synapse/Install/InstallServiceProvider.php
@@ -45,7 +45,7 @@ class InstallServiceProvider implements ServiceProviderInterface
 
             $command->setDatabaseAdapter($app['db']);
             $command->setAppVersion($app['version']);
-            $command->setAppEnv($app['env']);
+            $command->setAppEnv($app['environment']);
             $command->setRunMigrationsCommand($app['migrations.run-proxy']);
             $command->setGenerateInstallCommand($app['install.generate-proxy']);
 


### PR DESCRIPTION
## Description

When trying to create/provision an instance, we get an error that looks like this:
![screen shot 2014-08-21 at 8 07 33 am](https://cloud.githubusercontent.com/assets/819455/3998054/ee7ac140-2944-11e4-9cbe-d85b30a6d9f7.png)
We believe we have identified that the cause is this line:
https://github.com/synapsestudios/synapse-base/blob/92f7f5eaea034e532744a7f20d735aae4dc71ae4/src/Synapse/Install/InstallServiceProvider.php#L48
where `env` should instead say `environment`
## Details
- URL / Location: 
- Browser: 
- Credentials: 
- Expected Result: 
- Actual Result: 
- Steps to Reproduce: 
  1. STEPS
