### PR TITLE
Add RowNotExists Validator

### DIFF
--- a/src/Synapse/Validator/Constraints/RowNotExists.php
+++ b/src/Synapse/Validator/Constraints/RowNotExists.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Synapse\Validator\Constraints;
+
+/**
+ * Validator constraint meant to ensure that a row exists with the given ID
+ */
+class RowNotExists extends RowExists
+{
+    public $message = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
+}

--- a/src/Synapse/Validator/Constraints/RowNotExistsValidator.php
+++ b/src/Synapse/Validator/Constraints/RowNotExistsValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Synapse\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Synapse\Entity\AbstractEntity;
+
+/**
+ * Validator constraint meant to ensure that a row does not exists with the given value set in the given field.
+ *
+ * If no field specified, defaults to `id`.
+ */
+class RowNotExistsValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $entity = $constraint->getMapper()->findBy([
+            $constraint->field => $value
+        ]);
+
+        if (! $entity instanceof AbstractEntity) {
+            return;
+        }
+
+        $this->context->addViolation(
+            $constraint->message,
+            [
+                '{{ field }}' => $constraint->field,
+                '{{ value }}' => $value,
+            ],
+            $value
+        );
+    }
+}

--- a/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Test\Synapse\Validator\Constraints;
+
+use Synapse\TestHelper\ValidatorConstraintTestCase;
+use Synapse\Validator\Constraints\RowNotExistsValidator;
+use Test\Synapse\Entity\GenericEntity;
+
+class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
+{
+    public function setUp()
+    {
+        $this->validator = new RowNotExistsValidator;
+
+        parent::setUp($this->validator);
+
+        $this->setUpMapperInMockConstraint();
+    }
+
+    public function setUpMockConstraint()
+    {
+        $this->mockConstraint = $this->getMockBuilder('Synapse\Validator\Constraints\RowNotExists')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function setUpMapperInMockConstraint()
+    {
+        $this->mockMapper = $this->getMockBuilder('Test\Synapse\Mapper\Mapper')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockConstraint->expects($this->any())
+            ->method('getMapper')
+            ->will($this->returnValue($this->mockMapper));
+    }
+
+    public function withEntityFound()
+    {
+        $entity = new GenericEntity;
+
+        $this->mockMapper->expects($this->any())
+            ->method('findBy')
+            ->will($this->returnValue($entity));
+    }
+
+    public function withEntityNotFound()
+    {
+        $this->mockMapper->expects($this->any())
+            ->method('findBy')
+            ->will($this->returnValue(false));
+    }
+
+    public function expectingEntitySearchedForWithFieldAndValue($field, $value)
+    {
+        $wheres = [$field => $value];
+
+        $this->mockMapper->expects($this->once())
+            ->method('findBy')
+            ->with($this->equalTo($wheres));
+    }
+
+    public function validateWithValue($value)
+    {
+        return $this->validator->validate($value, $this->mockConstraint);
+    }
+
+    public function testValidateAddsNoViolationsIfEntityNotFound()
+    {
+        $this->withEntityNotFound();
+
+        $this->validateWithValue('foo');
+
+        $this->assertNoViolationsAdded();
+    }
+
+    public function testValidateAddsViolationIfEntityFound()
+    {
+        $value = 'foo';
+
+        $this->withEntityFound();
+
+        $this->validateWithValue($value);
+
+        $params = [
+            '{{ field }}' => 'id',
+            '{{ value }}' => $value,
+        ];
+
+        $this->assertViolationAdded(
+            'Entity must not exist with {{ field }} field equal to {{ value }}.',
+            $params,
+            $value
+        );
+    }
+
+    public function testValidateSearchesForEntityByFieldSetInConstraint()
+    {
+        $field = 'foo';
+        $value = 'bar';
+
+        $this->mockConstraint->field = $field;
+
+        $this->expectingEntitySearchedForWithFieldAndValue($field, $value);
+
+        $this->validateWithValue($value);
+    }
+}


### PR DESCRIPTION
## Add RowNotExists Validator
### Acceptance Criteria
1. `RowNotExists` validator constraint exists.
2. Works just like `RowExists` constraint but returns `false` rather than `true` if the row exists.
### Tasks
- Create validator and constraint.
### Additional Notes
- None
