### PR TITLE
Remove Route Dependency in AbstractConsoleWork

### DIFF
--- a/src/Synapse/Work/AbstractConsoleWork.php
+++ b/src/Synapse/Work/AbstractConsoleWork.php
@@ -65,11 +65,9 @@ abstract class AbstractConsoleWork
         $defaultRoutes->define($app);
         $defaultServices->register($app);
 
-        // Set the application-specific routes and services
-        $appRoutes   = new \Application\Routes;
+        // Set the application-specific services
         $appServices = new \Application\Services;
 
-        $appRoutes->define($app);
         $appServices->register($app);
 
         return $app;


### PR DESCRIPTION
### Remove dependency to Application\Routes in Synapse\Work\AbstractConsoleWork

Synapse\Work\AbstractConsoleWork has a dependency to Application\Routes which is unnecessary. Any console commands would be registered in Application\Services. Commands should only be registered in service providers.
## ACs
1. AbstractConsoleWork only registers app services, not app routes
