### PR TITLE
Fix AbstractConsoleWork

### DIFF
--- a/src/Synapse/Work/AbstractConsoleWork.php
+++ b/src/Synapse/Work/AbstractConsoleWork.php
@@ -36,7 +36,7 @@ abstract class AbstractConsoleWork
 
         // Output error details to the console if available
         try {
-            $command->execute($input, $output);
+            $command->run($input, $output);
         } catch (\Exception $e) {
             $output->writeln('Exception: '.$e->getMessage());
             $output->writeln('Code: '.$e->getCode());


### PR DESCRIPTION
## Description

In #97 `AbstractConsoleWork` was changed to call `execute` (not `run`) on the console command. This was due to some confusion.

`Symfony\Component\Console\Command\Command` defines `execute` as a private method and `run` as (essentially) the public interface to that method.

It was correct to call `run` on the command. The problem was that the units of work were getting the pseudo command -- not the command proxy. (Which, confusingly, must implement `Synapse\Command\CommandInterface` which defines `execute` as a public method.)

When the command proxy pattern is employed, an `AbstractConsoleWork` that runs that command should run the **proxy**, not the pseudo-command behind the proxy. This way, `AbstractConsoleCommand` can work for console commands regardless of whether a proxy is employed.
