### PR TITLE
Fatal Error (E_ERROR): Call to a member function validate() on a non-object

### DIFF
--- a/src/Synapse/User/UserServiceProvider.php
+++ b/src/Synapse/User/UserServiceProvider.php
@@ -60,7 +60,8 @@ class UserServiceProvider implements ServiceProviderInterface
             $controller = new UserController();
             $controller
                 ->setUserService($app['user.service'])
-                ->setUserValidator($app['user.validator']);
+                ->setUserValidator($app['user.validator'])
+                ->setUserRegistrationValidator($app['user-registration.validator']);
             return $controller;
         });
 


### PR DESCRIPTION
## Description

When trying to create a new user, the user controller is trying to call validate() on the userRegistrationValidator object, which doesn't get set in the user service provider.

Introduced by #77.
## Details
- URL: `/users`
- Console Error: 
  Fatal Error (E_ERROR): `Call to a member function validate() on a non-object {"code":1,"message":"Call to a member function validate() on a non-object","file":"/vagrant/vendor/synapsestudios/synapse-base/src/Synapse/User/UserController.php","line":62}`
