### PR TITLE
Update FinderTrait::findBy() to pass $options to addJoins() call

### DIFF
--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -51,7 +51,7 @@ trait FinderTrait
 
         $this->setColumns($query, $options);
 
-        $wheres = $this->addJoins($query, $wheres);
+        $wheres = $this->addJoins($query, $wheres, $options);
 
         $this->addWheres($query, $wheres, $options);
 


### PR DESCRIPTION
## Update FinderTrait::findBy() to pass $options to addJoins() call
### Acceptance Criteria
1. When the findBy method adds joins it will now pass along the $options argument
2. A test will exist to make sure the $options param is making it to the addjoins method
