### PR TITLE
Catch AccessDeniedHttpExceptions

### DIFF
--- a/src/Synapse/Application/Routes.php
+++ b/src/Synapse/Application/Routes.php
@@ -3,6 +3,7 @@
 namespace Synapse\Application;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Synapse\Application;
 
 /**
@@ -16,6 +17,11 @@ class Routes implements RoutesInterface
      */
     public function define(Application $app)
     {
+        $app->error(function (\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException $e, $code) {
+            $body = ['error' => 'Access denied'];
+            return new JsonResponse($body, 403);
+        });
+
         $app->error(function (\Synapse\Rest\Exception\MethodNotImplementedException $e, $code) {
             $response = new Response('Method not implemented');
             $response->setStatusCode(501);


### PR DESCRIPTION
## Catch AccessDeniedHttpExceptions
### Acceptance Criteria
1. When a user visits an endpoint but is restricted from access via access rules, the AccessDeniedHttpException is caught before it gets to Silex.
2. The Exception is caught and simply turned into a 403 JSON response with the following body:

```
{"error":"Access denied"}
```
### Tasks
- Catch AccessDeniedHttpExceptions in `Synapse\Application\Routes` and return the JSON response.
