### PR TITLE
Update createNotFoundResponse to return same response as a missing route

### DIFF
--- a/src/Synapse/Controller/AbstractController.php
+++ b/src/Synapse/Controller/AbstractController.php
@@ -29,7 +29,7 @@ abstract class AbstractController implements UrlGeneratorAwareInterface, LoggerA
     public function createNotFoundResponse()
     {
         $data = [
-            'message' => 'Not Found'
+            'message' => 'Not found'
         ];
 
         $response = new JsonResponse($data, 404);


### PR DESCRIPTION
## Update createNotFoundResponse to return same response as a missing route
### Acceptance Criteria
1. `AbstractController::createNotFoundResponse` returns a 404 with the following body:

``` JSON
{
    "messages" : "Not found"
}
```
### Tasks
- Modify AbstractController::createNotFoundResponse to return `JsonResponse` rather than `Response`.
### Additional Notes
- Related to #133 
