### PR TITLE
Modify InserterTrait to handle hard coded IDs

### DIFF
--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -52,7 +52,9 @@ trait InserterTrait
 
         $result = $statement->execute();
 
-        $entity->setId($result->getGeneratedValue());
+        if (! $entity->getId()) {
+            $entity->setId($result->getGeneratedValue());
+        }
 
         return $entity;
     }

--- a/tests/Test/Synapse/Mapper/InserterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/InserterTraitTest.php
@@ -120,4 +120,25 @@ class InserterTraitTest extends MapperTestCase
 
         $this->assertNotNull($entity->getCreated());
     }
+
+    public function testInsertSetsGeneratedAutoIncrementIdOnEntityIfEntityDoesNotAlreadyHaveAnId()
+    {
+        $entity     = $this->createEntityToInsert();
+        $expectedId = self::GENERATED_ID;
+
+        $this->mapper->insert($entity);
+
+        $this->assertEquals($expectedId, $entity->getId());
+    }
+
+    public function testInsertDoesNotSetIdOnEntityIfEntityAlreadyHasAnId()
+    {
+        $entity     = $this->createEntityToInsert();
+        $expectedId = self::GENERATED_ID + 1;
+
+        $entity->setId($expectedId);
+        $this->mapper->insert($entity);
+
+        $this->assertEquals($expectedId, $entity->getId());
+    }
 }


### PR DESCRIPTION
## Modify InserterTrait to handle hard coded IDs
### Acceptance Criteria
1. InserterTrait only sets ID of entity to generated value if entity did not have ID upon insert.
### Tasks
- Add condition
