### PR TITLE
Add protected typecasting setters to DataObject

### DIFF
--- a/src/Synapse/Stdlib/DataObject.php
+++ b/src/Synapse/Stdlib/DataObject.php
@@ -142,4 +142,37 @@ abstract class DataObject implements ArraySerializableInterface
 
         return $property;
     }
+
+    /**
+     * Set the given field with the given value typecasted as an integer
+     *
+     * @param string $field Field to set
+     * @param mixed  $value Value to set
+     */
+    protected function setAsInteger($field, $value)
+    {
+        $this->object[$field] = (int) $value;
+    }
+
+    /**
+     * Set the given field with the given value typecasted as a boolean
+     *
+     * @param string $field Field to set
+     * @param mixed  $value Value to set
+     */
+    protected function setAsBoolean($field, $value)
+    {
+        $this->object[$field] = (bool) $value;
+    }
+
+    /**
+     * Set the given field with the given value typecasted as a string
+     *
+     * @param string $field Field to set
+     * @param mixed  $value Value to set
+     */
+    protected function setAsString($field, $value)
+    {
+        $this->object[$field] = (string) $value;
+    }
 }

--- a/tests/Test/Synapse/Stdlib/DataObjectTest.php
+++ b/tests/Test/Synapse/Stdlib/DataObjectTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Test\Synapse\Stdlib;
+
+use PHPUnit_Framework_TestCase;
+
+class DataObjectTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->dataObject = new TestDataObject();
+    }
+
+    public function testStringSetterOverrideSetsValueAsString()
+    {
+        $this->dataObject->setString(1);
+
+        $this->assertEquals('1', $this->dataObject->getString());
+    }
+
+    public function testIntegerSetterOverrideSetsValueAsInteger()
+    {
+        $this->dataObject->setInteger('1');
+
+        $this->assertEquals(1, $this->dataObject->getInteger());
+    }
+
+    public function testBooleanSetterOverrideSetsValueAsBoolean()
+    {
+        $this->dataObject->setBoolean(1);
+
+        $this->assertEquals(true, $this->dataObject->getBoolean());
+    }
+}

--- a/tests/Test/Synapse/Stdlib/TestDataObject.php
+++ b/tests/Test/Synapse/Stdlib/TestDataObject.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Test\Synapse\Stdlib;
+
+use Synapse\Stdlib\DataObject;
+
+class TestDataObject extends DataObject
+{
+    protected $object = [
+        'string'  => null,
+        'integer' => null,
+        'boolean' => null,
+        'foo'     => null,
+    ];
+
+    public function setString($value)
+    {
+        $this->setAsString('string', $value);
+    }
+
+    public function setInteger($value)
+    {
+        $this->setAsInteger('integer', $value);
+    }
+
+    public function setBoolean($value)
+    {
+        $this->setAsBoolean('boolean', $value);
+    }
+}


### PR DESCRIPTION
## Add protected typecasting setters to DataObject
### Acceptance Criteria
1. `DataObject::setAsInteger($field, $value)` sets the given field as an integer.
2. `DataObject::setAsBoolean($field, $value)` sets the given field as a boolean.
3. `DataObject::setAsString($field, $value)` sets the given field as a string.
### Tasks
- Add methods.
### Additional Notes
- This code has already been written in a couple of projects -- might as well make it part of synapse base so that overwritten setters can utilize it.
