### PR TITLE
Arr::path() does not work for numerical string indexes with leading 0's

### DIFF
--- a/src/Synapse/Stdlib/Arr.php
+++ b/src/Synapse/Stdlib/Arr.php
@@ -116,11 +116,6 @@ class Arr
         do {
             $key = array_shift($keys);
 
-            if (ctype_digit($key)) {
-                // Make the key an integer
-                $key = (int) $key;
-            }
-
             if (isset($array[$key])) {
                 if ($keys) {
                     if (Arr::isArray($array[$key])) {
@@ -133,6 +128,26 @@ class Arr
                 } else {
                     // Found the path requested
                     return $array[$key];
+                }
+            } elseif (ctype_digit($key)) {
+                $key = (int) $key;
+
+                if (isset($array[$key])) {
+                    if ($keys) {
+                        if (Arr::isArray($array[$key])) {
+                            // Dig down into the next part of the path
+                            $array = $array[$key];
+                        } else {
+                            // Unable to dig deeper
+                            break;
+                        }
+                    } else {
+                        // Found the path requested
+                        return $array[$key];
+                    }
+                } else {
+                    // Unable to dig deeper
+                    break;
                 }
             } elseif ($key === '*') {
                 // Handle wildcards

--- a/tests/Test/Synapse/Stdlib/ArrTest.php
+++ b/tests/Test/Synapse/Stdlib/ArrTest.php
@@ -424,7 +424,9 @@ class ArrTest extends PHPUnit_Framework_TestCase
                 2 => ['name' => 'john', 'interests' => ['hocky' => ['length' => 2], 'football' => []]],
                 3 => 'frank', // Issue #3194
             ],
-            'object' => new ArrayObject(['iterator' => true]), // Iterable object should work exactly the same
+            'object'  => new ArrayObject(['iterator' => true]), // Iterable object should work exactly the same
+            'foo'     => ['0123' => 'bar'],
+            'numbers' => [123 => [456 => '1']],
         ];
 
         return [
@@ -454,6 +456,11 @@ class ArrTest extends PHPUnit_Framework_TestCase
             // Path as array, issue #3260
             [$array['users'][2]['name'], $array, ['users', 2, 'name']],
             [$array['object']['iterator'], $array, 'object.iterator'],
+            // Path accepts numerical string indexes with leading zeroes #140
+            ['bar', $array, 'foo.0123'],
+            ['1', $array, 'numbers.0123.0456'],
+            [null, $array, 'numbers.0122'],
+            [null, $array, 'numbers.0123.0456.notfound'],
         ];
     }
 


### PR DESCRIPTION
## Arr::path() does not work for numerical string indexes with leading 0's

The following doesn't work.

```
$array = [
  'foo' => [
    '123' => 'bar'
  ]
];

$this->assertEquals('bar', Arr::path($array, 'foo.123'));
```

Write a test! Just copy and paste :point_up:
