### PR TITLE
Add getUser method to SecurityAwareTrait

### DIFF
--- a/src/Synapse/Security/SecurityAwareTrait.php
+++ b/src/Synapse/Security/SecurityAwareTrait.php
@@ -31,7 +31,7 @@ trait SecurityAwareTrait
      *
      * @see TokenInterface::getUser()
      */
-    public function user()
+    public function getUser()
     {
         if (null === $token = $this->security->getToken()) {
             return null;
@@ -42,5 +42,16 @@ trait SecurityAwareTrait
         }
 
         return $user;
+    }
+
+    /**
+     * Alias for the getUser() function
+     * To be deprecated in v2.0
+     *
+     * @return mixed
+     */
+    public function user()
+    {
+        return $this->getUser();
     }
 }


### PR DESCRIPTION
## Add getUser method to SecurityAwareTrait, so that the user can be accessed with a method that is a verb, not a noun
### Acceptance Criteria
1. `user` method is renamed to `getUser`.
2. New `user` method is created as an alias to `getUser`. (To be deprecated in v2.0)
### Tasks
- Modify SecurityAwareTrait
### Additional Notes
- It is our convention that method names should always be verbs succinctly describing what the method does. Using a noun for the name describing what it returns violates this pattern.
