### PR TITLE
Add create204Response method

### DIFF
--- a/src/Synapse/Controller/AbstractController.php
+++ b/src/Synapse/Controller/AbstractController.php
@@ -134,4 +134,14 @@ abstract class AbstractController implements UrlGeneratorAwareInterface, LoggerA
             422
         );
     }
+
+    /**
+     * Create and return a 204 response with an empty string as the body
+     *
+     * @return Response
+     */
+    protected function create204Response()
+    {
+        return $this->createSimpleResponse(204, '');
+    }
 }


### PR DESCRIPTION
## Add create204Response method

Minor "annoyance" optimization here. Whenever we make 204 responses, we always have to do this:

``` PHP
return $this->createSimpleResponse(204, '');
```

But the specification says 204 responses should _always_ have an empty response body. It's very slightly annoying to always have to specify it. It would be nice to just do:

``` PHP
return $this->create204Response();
```
### Acceptance Criteria
1. `AbstractController::create204Response` method exists, and returns an HttpFoundation Response object with 204 as the status code and an empty string as the body.
### Tasks
- Create method
