### PR TITLE
Return WWW-Authenticate header with 401 responses as OAuth2 spec says

### DIFF
--- a/src/Synapse/Security/Firewall/OAuth2Listener.php
+++ b/src/Synapse/Security/Firewall/OAuth2Listener.php
@@ -40,7 +40,7 @@ class OAuth2Listener implements ListenerInterface
         if (! $request->headers->has('Authorization') ||
             preg_match($regex, $request->headers->get('Authorization'), $matches) !== 1
         ) {
-            $event->setResponse($this->getForbiddenReponse());
+            $event->setResponse($this->getInvalidRequestResponse());
             return;
         }
 
@@ -54,20 +54,50 @@ class OAuth2Listener implements ListenerInterface
 
             return;
         } catch (AuthenticationException $failed) {
-            $event->setResponse($this->getForbiddenReponse());
+            $event->setResponse($this->getInvalidTokenReponse());
             return;
         }
 
-        $event->setResponse($this->getForbiddenReponse());
+        $event->setResponse($this->getInvalidTokenReponse());
     }
 
     /**
-     * Return a 401 response object
+     * Return an invalid_token response object
      *
-     * @return Response
+     * @return JsonResponse
      */
-    protected function getForbiddenReponse()
+    protected function getInvalidTokenReponse()
     {
-        return new JsonResponse(['message' => 'Unauthorized'], 401);
+        return $this->getUnauthorizedResponse(401, 'invalid_token');
+    }
+
+    /**
+     * Return an invalid_request response object
+     *
+     * @return JsonResponse
+     */
+    protected function getInvalidRequestResponse()
+    {
+        return $this->getUnauthorizedResponse(400, 'invalid_request');
+    }
+
+    /**
+     * Return an "Unauthorized" request including a WWW-Authenticate header per
+     * the OAuth2 specification
+     *
+     * @param  integer $statusCode HTTP status code to return in response
+     * @param  string  $error      Error message in WWW-Authenticate header
+     * @return JsonResponse
+     * @link   https://tools.ietf.org/html/rfc6750#section-3
+     */
+    protected function getUnauthorizedResponse($statusCode, $error = null)
+    {
+        $authenticateHeader  = 'Bearer';
+        $authenticateHeader .= $error === null ? '' : sprintf(' error="%s"', $error);
+
+        $body    = ['message' => 'Unauthorized'];
+        $headers = ['WWW-Authenticate' => $authenticateHeader];
+
+        return new JsonResponse($body, $statusCode, $headers);
     }
 }

--- a/src/Synapse/Security/Firewall/OAuth2OptionalListener.php
+++ b/src/Synapse/Security/Firewall/OAuth2OptionalListener.php
@@ -37,10 +37,10 @@ class OAuth2OptionalListener extends OAuth2Listener
 
             return;
         } catch (AuthenticationException $failed) {
-            $event->setResponse($this->getForbiddenReponse());
+            $event->setResponse($this->getInvalidTokenReponse());
             return;
         }
 
-        $event->setResponse($this->getForbiddenReponse());
+        $event->setResponse($this->getInvalidTokenReponse());
     }
 }


### PR DESCRIPTION
## Return WWW-Authenticate header with 401 responses

Looks like it can just say: `WWW-Authenticate: Bearer`
### Acceptance Criteria
1. If the user makes a request for a protected resource without including an `Authorization` header in the format `Bearer [token_goes_here]`, the OAuth2Listener returns 400 with `WWW-Authenticate: Bearer error="invalid_request"` header.
2. If the user makes a request for a protected resource with an invalid or expired token, the OAuth2Listener (or OAuth2OptionalListener) returns 401 with `WWW-Authenticate: Bearer error="invalid_token"` header.
### Tasks
- Update Synapse\Security\Firewall\OAuth2Listener::getForbiddenResponse()
### Additional Notes
- ~~http://self-issued.info/docs/draft-ietf-oauth-v2-bearer.html#authn-header~~ Never mind, that is a draft.
- [The real OAuth2 Spec](https://tools.ietf.org/html/rfc6749)
- The related spec: [OAuth 2 Authorization Framework: Bearer Token Usage](https://tools.ietf.org/html/rfc6750#section-3). (See section 3 and specifically 3.1)
