### PR TITLE
Make EmailService more generic

### DIFF
--- a/src/Synapse/Email/EmailService.php
+++ b/src/Synapse/Email/EmailService.php
@@ -5,7 +5,6 @@ namespace Synapse\Email;
 use Synapse\Resque\Resque;
 use Synapse\Stdlib\Arr;
 use Synapse\Mapper\AbstractMapper;
-use Synapse\Entity\AbstractEntity;
 
 /**
  * General purpose service for handling email entities
@@ -88,7 +87,7 @@ class EmailService
      * @param  EmailEntity $email
      * @return string
      */
-    public function enqueueSendEmailJob(AbstractEntity $email)
+    public function enqueueSendEmailJob(EmailEntity $email)
     {
         return $this->resque->enqueue(
             'email',

--- a/src/Synapse/Email/EmailService.php
+++ b/src/Synapse/Email/EmailService.php
@@ -5,6 +5,7 @@ namespace Synapse\Email;
 use Synapse\Resque\Resque;
 use Synapse\Stdlib\Arr;
 use Synapse\Mapper\AbstractMapper;
+use Synapse\Entity\AbstractEntity;
 
 /**
  * General purpose service for handling email entities
@@ -70,7 +71,7 @@ class EmailService
             'sender_name'  => Arr::path($this->emailConfig, 'defaults.sender.name'),
         ];
 
-        $email = new EmailEntity;
+        $email = $this->emailMapper->getPrototype();
 
         $email = $email->exchangeArray(
             array_merge($defaults, $data)
@@ -87,7 +88,7 @@ class EmailService
      * @param  EmailEntity $email
      * @return string
      */
-    public function enqueueSendEmailJob(EmailEntity $email)
+    public function enqueueSendEmailJob(AbstractEntity $email)
     {
         return $this->resque->enqueue(
             'email',

--- a/src/Synapse/Email/EmailService.php
+++ b/src/Synapse/Email/EmailService.php
@@ -4,6 +4,7 @@ namespace Synapse\Email;
 
 use Synapse\Resque\Resque;
 use Synapse\Stdlib\Arr;
+use Synapse\Mapper\AbstractMapper;
 
 /**
  * General purpose service for handling email entities
@@ -28,7 +29,7 @@ class EmailService
     /**
      * @param EmailMapper $mapper
      */
-    public function setEmailMapper(EmailMapper $mapper)
+    public function setEmailMapper(AbstractMapper $mapper)
     {
         $this->emailMapper = $mapper;
         return $this;

--- a/src/Synapse/Email/SendEmailCommand.php
+++ b/src/Synapse/Email/SendEmailCommand.php
@@ -6,7 +6,6 @@ use Synapse\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Synapse\Mapper\AbstractMapper;
-use Synapse\Entity\AbstractEntity;
 
 use LogicException;
 use OutOfBoundsException;

--- a/src/Synapse/Email/SendEmailCommand.php
+++ b/src/Synapse/Email/SendEmailCommand.php
@@ -5,6 +5,8 @@ namespace Synapse\Email;
 use Synapse\Command\CommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Synapse\Mapper\AbstractMapper;
+use Synapse\Entity\AbstractEntity;
 
 use LogicException;
 use OutOfBoundsException;
@@ -26,7 +28,7 @@ class SendEmailCommand implements CommandInterface
      *
      * @param EmailMapper $emailMapper
      */
-    public function setEmailMapper(EmailMapper $emailMapper)
+    public function setEmailMapper(AbstractMapper $emailMapper)
     {
         $this->emailMapper = $emailMapper;
     }

--- a/src/Synapse/Email/SenderInterface.php
+++ b/src/Synapse/Email/SenderInterface.php
@@ -2,8 +2,6 @@
 
 namespace Synapse\Email;
 
-use Synapse\Entity\AbstractEntity;
-
 interface SenderInterface
 {
     /**
@@ -12,5 +10,5 @@ interface SenderInterface
      * @param  Email  $email
      * @return mixed         Result of attempt to send email
      */
-    public function send(AbstractEntity $email);
+    public function send(EmailEntity $email);
 }

--- a/src/Synapse/Email/SenderInterface.php
+++ b/src/Synapse/Email/SenderInterface.php
@@ -2,6 +2,8 @@
 
 namespace Synapse\Email;
 
+use Synapse\Entity\AbstractEntity;
+
 interface SenderInterface
 {
     /**
@@ -10,5 +12,5 @@ interface SenderInterface
      * @param  Email  $email
      * @return mixed         Result of attempt to send email
      */
-    public function send(EmailEntity $email);
+    public function send(AbstractEntity $email);
 }


### PR DESCRIPTION
## Make EmailService more generic

### Acceptance Criteria
1. The function prototype for `EmailService::setMailMapper()` will no longer specify EmailMapper and will instead specify AbstractMapper.
1. `createFromArray()` method will use the entity returned from the mapper's `getPrototype()` method instead of `EmailEntity`
1. The prototype for `enqueueSendEmailJob()` will require `AbstractEntity` instead of `EmailEntity`