### PR TITLE
Support NOT IN in finder trait

### DIFF
--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -13,6 +13,9 @@ use Zend\Db\Sql\Predicate\Like;
 use Zend\Db\Sql\Predicate\NotLike;
 use Zend\Db\Sql\Predicate\Operator;
 use Zend\Db\Sql\Predicate\In;
+use Zend\Db\Sql\Predicate\NotIn;
+use Zend\Db\Sql\Predicate\IsNull;
+use Zend\Db\Sql\Predicate\IsNotNull;
 
 /**
  * Use this trait to add find functionality to AbstractMappers.
@@ -280,6 +283,17 @@ trait FinderTrait
                     case 'IN':
                         $predicate = new In($where[0], $where[2]);
                         break;
+                    case 'NOT IN':
+                        $predicate = new NotIn($where[0], $where[2]);
+                        break;
+                    case 'IS':
+                        $predicate = new IsNull($where[0]);
+                        break;
+                    case 'IS NOT':
+                        $predicate = new IsNotNull($where[0]);
+                        break;
+                    default:
+                        throw new LogicException(sprintf('Invalid operator "%s"', $operator));
                 }
 
                 $query->where($predicate);

--- a/tests/Test/Synapse/Mapper/FinderTraitTest.php
+++ b/tests/Test/Synapse/Mapper/FinderTraitTest.php
@@ -341,6 +341,51 @@ class FinderTraitTest extends MapperTestCase
         $this->assertRegExpOnSqlString($regexp);
     }
 
+    public function testFindAllByFormsNotInWhereClausesCorrectly()
+    {
+        $inArray = ['bar', 'baz', 'qux'];
+
+        $this->mapper->findAllBy([
+            ['foo', 'NOT IN', $inArray]
+        ]);
+
+        $this->assertRegExpOnSqlString('/WHERE `foo` NOT IN \(\'bar\', \'baz\', \'qux\'\)/');
+    }
+
+    public function testFindAllByFormsIsNullClausesCorrectly()
+    {
+        $this->mapper->findAllBy([
+            ['foo', 'IS', 'NULL']
+        ]);
+
+        $regexp = '/WHERE `foo` IS NULL/';
+
+        $this->assertRegExpOnSqlString($regexp);
+
+        $this->mapper->findAllBy([
+            ['foo', 'IS', null]
+        ]);
+
+        $this->assertRegExpOnSqlString($regexp, 1);
+    }
+
+    public function testFindAllByFormsIsNotNullClausesCorrectly()
+    {
+        $this->mapper->findAllBy([
+            ['foo', 'IS NOT', 'NULL']
+        ]);
+
+        $regexp = '/WHERE `foo` IS NOT NULL/';
+
+        $this->assertRegExpOnSqlString($regexp);
+
+        $this->mapper->findAllBy([
+            ['foo', 'IS NOT', null]
+        ]);
+
+        $this->assertRegExpOnSqlString($regexp, 1);
+    }
+
     /**
      * @expectedException LogicException
      */


### PR DESCRIPTION
## Finder Trait supports the NOT IN clause

### Acceptance Criteria
1. Use  `Zend\Db\Sql\Predicate\NotIn` for NotIn operator in Finder Trait
1. Use  `Zend\Db\Sql\Predicate\IsNull` for NotIn operator in Finder Trait
1. Use  `Zend\Db\Sql\Predicate\IsNotNull` for NotIn operator in Finder Trait
1. `['column', 'IS', null]` is the syntax for accessing the `IS NULL` operator
1. Throw `LogicException` for missing predicates
