### PR TITLE
FinderTrait bug when wheres contains an array with exactly 3 elements as a value

### DIFF
--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -228,6 +228,8 @@ trait FinderTrait
     {
         foreach ($wheres as $key => $where) {
             if (is_array($where) && count($where) === 3) {
+                $leftOpRightSyntax = true;
+
                 $operator = $where[1];
 
                 switch ($operator)
@@ -293,13 +295,18 @@ trait FinderTrait
                         $predicate = new IsNotNull($where[0]);
                         break;
                     default:
-                        throw new LogicException(sprintf('Invalid operator "%s"', $operator));
+                        $leftOpRightSyntax = false;
+                        break;
                 }
 
-                $query->where($predicate);
+                if ($leftOpRightSyntax === false) {
+                    $predicate = [$key => $where];
+                }
             } else {
-                $query->where([$key => $where]);
+                $predicate = [$key => $where];
             }
+
+            $query->where($predicate);
         }
 
         return $query;

--- a/tests/Test/Synapse/Mapper/FinderTraitTest.php
+++ b/tests/Test/Synapse/Mapper/FinderTraitTest.php
@@ -386,6 +386,15 @@ class FinderTraitTest extends MapperTestCase
         $this->assertRegExpOnSqlString($regexp, 1);
     }
 
+    public function testFindAllByFormsInClausesWith3ItemsCorrectly()
+    {
+        $this->mapper->findAllBy([
+            'foo' => [1, 2, 3]
+        ]);
+
+        $this->assertRegExpOnSqlString('/WHERE `foo` IN \(\'1\', \'2\', \'3\'\)/');
+    }
+
     /**
      * @expectedException LogicException
      */


### PR DESCRIPTION
## Description
There's issue with our FinderTrait in synapse-base. It only happens when a wheres contains an array with exactly 3 elements as a value.

When an application gets a list of entity ids and uses the finder trait to find the entities that correspond to those ids, it adds a ‘where’ clause that looks like `[‘id’ => [1,2,3,4,5,6...]]`

BUT, when it’s an array of exactly 3 elements, it thinks you’re trying to set a where clause with a format like this: `[‘id’, ‘>’, ‘6']`

If you try to do a findAllBy with 3 id's, it will throw an error:
```
 "error": "Notice: Undefined variable: predicate",
```

## Details
Trevor Boone [10:47 AM] 
If I use the finder trait to search for records using an array of ids, e.g. `’id’ => [1,2,3,4,5,6…]`, it throws an error if I need to find exactly three ids

https://github.com/synapsestudios/synapse-base/blob/master/src/Synapse/Mapper/FinderTrait.php#L227
