### PR TITLE
Allow for better file naming in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Upcoming Release - up to 8cf951d
 * Have AbstractController implement TransactionAwareInterface
 * Add test helper InjectMockTransactionTrait
 * Have ControllerTestCase use InjectMockTransactionTrait
+* Change in migration class naming for easier sorting
 
 0.2.6 (2014-08-08)
 -----------------

--- a/src/Synapse/Migration/CreateMigrationCommand.php
+++ b/src/Synapse/Migration/CreateMigrationCommand.php
@@ -5,7 +5,6 @@ namespace Synapse\Migration;
 use Synapse\Command\CommandInterface;
 use Synapse\View\Migration\Create as CreateMigrationView;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -19,7 +18,7 @@ class CreateMigrationCommand implements CommandInterface
     /**
      * View for new migration files
      *
-     * @var Synapse\View\Migration\Create
+     * @var \Synapse\View\Migration\Create
      */
     protected $newMigrationView;
 
@@ -28,7 +27,6 @@ class CreateMigrationCommand implements CommandInterface
     /**
      * Set the injected new migration view, call the parent constructor
      *
-     * @param string              $name             Name of the console command
      * @param CreateMigrationView $newMigrationView
      */
     public function __construct(CreateMigrationView $newMigrationView)
@@ -40,6 +38,8 @@ class CreateMigrationCommand implements CommandInterface
      * Set the namespace for the migrations
      *
      * @param string $namespace
+     *
+     * @return $this
      */
     public function setMigrationNamespace($namespace)
     {

--- a/src/Synapse/Migration/CreateMigrationCommand.php
+++ b/src/Synapse/Migration/CreateMigrationCommand.php
@@ -57,7 +57,7 @@ class CreateMigrationCommand implements CommandInterface
     {
         $description = $input->getArgument('description');
         $time        = date('YmdHis');
-        $classname   = $this->classname($time, $description);
+        $classname   = $this->generateClassName($time, $description);
         $filepath    = APPDIR.'/src/'.$this->namespaceToPath().$classname.'.php';
 
         if (! is_dir(dirname($filepath))) {
@@ -81,24 +81,24 @@ class CreateMigrationCommand implements CommandInterface
     /**
      * Get the name of the new migration class
      *
-     * Converts description to camelCase and appends timestamp.
+     * Converts description to PascalCase and prepends constant string and timestamp.
      * Example:
      *     // From:
      *     Example description of a migration
      *
      *     // To:
-     *     ExampleDescriptionOfAMigration20140220001906
+     *     Migration20140220001906ExampleDescriptionOfAMigration
      *
      * @param  string $time        Timestamp
      * @param  string $description User-provided description of new migration
      * @return string
      */
-    protected function classname($time, $description)
+    protected function generateClassName($time, $description)
     {
         $description = substr(strtolower($description), 0, 30);
         $description = ucwords($description);
         $description = preg_replace('/[^a-zA-Z]+/', '', $description);
-        return $description.$time;
+        return 'Migration'.$time.$description;
     }
 
     /**

--- a/tests/Test/Synapse/Migration/CreateMigrationCommandTest.php
+++ b/tests/Test/Synapse/Migration/CreateMigrationCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Test\Synapse\Migration;
+
+use Synapse\Migration\CreateMigrationCommand;
+
+class CreateMigrationCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGenerateClassNameGeneratesCorrectName() {
+        $time = '19990101121256';
+        $description = "gordon ipsum solar robot";
+
+        // monkey code the method to be accessible
+        $method = new \ReflectionMethod('Synapse\Migration\CreateMigrationCommand', 'generateClassName');
+        $method->setAccessible(true);
+
+        $command = new CreateMigrationCommand(new \Synapse\View\Migration\Create(new \Mustache_Engine()));
+
+        $resultClassName = $method->invoke($command, $time, $description);
+
+        $this->assertEquals('Migration'.$time.'GordonIpsumSolarRobot', $resultClassName);
+    }
+}


### PR DESCRIPTION
## Currently, migration files start with the description followed by the date which is unsortable
Making the files start with a constant string (as classes cannot begin with an integer), followed by the date will allow them to be sortable alphabetically.

### Acceptance Criteria
1. New migration files are created in a way which sorting by filename shows them in the order they were created.

### Tasks
- Modify CreateMigrationCommand:classname method to use format:
Migration[datetimestamp][PascalCasedDescription]
