### PR TITLE
Add starting message to migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Upcoming Release - up to 8cf951d
 * Have AbstractController implement TransactionAwareInterface
 * Add test helper InjectMockTransactionTrait
 * Have ControllerTestCase use InjectMockTransactionTrait
+* Add output when starting a specific migration
+* Add times for each migration and total time
 
 0.2.6 (2014-08-08)
 -----------------


### PR DESCRIPTION
## Currently only "DONE" messages are printed during migrations
When errors occur, it is difficult to find what the next migration might be.

### Acceptance Criteria
1. Logs a "STARTING" message before executing each migration

### Tasks
- Add another writeln in RunMigrationsCommand
