### PR TITLE
Add TransactionAwareInterface and TransactionAwareTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+Upcoming Release - up to 8cf951d
+--------------------------------
+* Add TransactionAwareInterface and TransactionAwareTrait
+* Auto-inject Transaction object into classes implementing TransactionAwareInterface
+* Have AbstractController implement TransactionAwareInterface
+* Add test helper InjectMockTransactionTrait
+* Have ControllerTestCase use InjectMockTransactionTrait
+
 0.2.6 (2014-08-08)
 -----------------
 

--- a/src/Synapse/Controller/AbstractController.php
+++ b/src/Synapse/Controller/AbstractController.php
@@ -22,7 +22,12 @@ use Zend\Stdlib\ArraySerializableInterface;
 /**
  * Abstract controller defining universal helper methods
  */
-abstract class AbstractController implements UrlGenInterface, LoggerInterface, DebugInterface, ValidationInterface
+abstract class AbstractController implements
+    UrlGenInterface,
+    LoggerInterface,
+    DebugInterface,
+    ValidationInterface,
+    TransactionAwareInterface
 {
     use UrlGeneratorAwareTrait,
         LoggerAwareTrait,

--- a/src/Synapse/Controller/AbstractController.php
+++ b/src/Synapse/Controller/AbstractController.php
@@ -4,6 +4,9 @@ namespace Synapse\Controller;
 
 use Synapse\Application\UrlGeneratorAwareInterface as UrlGenInterface;
 use Synapse\Application\UrlGeneratorAwareTrait;
+use Synapse\Db\Transaction;
+use Synapse\Db\TransactionAwareInterface;
+use Synapse\Db\TransactionAwareTrait;
 use Synapse\Debug\DebugModeAwareInterface as DebugInterface;
 use Synapse\Debug\DebugModeAwareTrait;
 use Synapse\Validator\ValidationErrorFormatterAwareInterface as ValidationInterface;
@@ -21,7 +24,11 @@ use Zend\Stdlib\ArraySerializableInterface;
  */
 abstract class AbstractController implements UrlGenInterface, LoggerInterface, DebugInterface, ValidationInterface
 {
-    use UrlGeneratorAwareTrait, LoggerAwareTrait, DebugModeAwareTrait, ValidationErrorFormatterAwareTrait;
+    use UrlGeneratorAwareTrait,
+        LoggerAwareTrait,
+        DebugModeAwareTrait,
+        ValidationErrorFormatterAwareTrait,
+        TransactionAwareTrait;
 
     /**
      * Create and return a 404 response object

--- a/src/Synapse/Db/DbServiceProvider.php
+++ b/src/Synapse/Db/DbServiceProvider.php
@@ -29,6 +29,14 @@ class DbServiceProvider implements ServiceProviderInterface
             return new Transaction($app['db']);
         });
 
+        $app->initializer(
+            'Synapse\\Db\\TransactionAwareInterface',
+            function ($object, $app) {
+                $object->setTransaction($app['db.transaction']);
+                return $object;
+            }
+        );
+
         $this->registerMapperInitializer($app);
     }
 

--- a/src/Synapse/Db/TransactionAwareInterface.php
+++ b/src/Synapse/Db/TransactionAwareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Synapse\Db;
+
+interface TransactionAwareInterface
+{
+    /**
+     * Set transaction object
+     *
+     * @param Transation $transaction
+     */
+    public function setTransaction(Transaction $transaction);
+}

--- a/src/Synapse/Db/TransactionAwareTrait.php
+++ b/src/Synapse/Db/TransactionAwareTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Synapse\Db;
+
+trait TransactionAwareTrait
+{
+    /**
+     * @var Transaction;
+     */
+    protected $transaction;
+
+    public function setTransaction(Transaction $transaction)
+    {
+        $this->transaction = $transaction;
+    }
+}

--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -7,11 +7,14 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolation;
 use Synapse\Controller\AbstractController;
 use Synapse\Stdlib\Arr;
+use Synapse\TestHelper\InjectMockTransactionTrait;
 use Synapse\User\UserEntity;
 use stdClass;
 
 abstract class ControllerTestCase extends AbstractSecurityAwareTestCase
 {
+    use InjectMockTransactionTrait;
+
     public function createJsonRequest($method, array $params = [])
     {
         $this->request = new Request(
@@ -51,15 +54,6 @@ abstract class ControllerTestCase extends AbstractSecurityAwareTestCase
         $mockValidationErrorFormatter->expects($this->any())
             ->method('groupViolationsByField')
             ->will($this->returnValue(['foo' => 'bar']));
-    }
-
-    public function injectMockTransaction(AbstractController $controller)
-    {
-        $this->mockTransaction = $this->getMockBuilder('Synapse\Db\Transaction')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $controller->setTransaction($this->mockTransaction);
     }
 
     /**

--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -52,4 +52,24 @@ abstract class ControllerTestCase extends AbstractSecurityAwareTestCase
             ->method('groupViolationsByField')
             ->will($this->returnValue(['foo' => 'bar']));
     }
+
+    public function injectMockTransaction(AbstractController $controller)
+    {
+        $this->mockTransaction = $this->getMockBuilder('Synapse\Db\Transaction')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $controller->setTransaction($this->mockTransaction);
+    }
+
+    /**
+     * Shortcut for calling the other inject methods in this class
+     *
+     * @param  AbstractController $controller
+     */
+    public function injectCommonDependencies(AbstractController $controller)
+    {
+        $this->injectMockTransaction($controller);
+        $this->injectMockValidationErrorFormatter($controller);
+    }
 }

--- a/src/Synapse/TestHelper/InjectMockTransactionTrait.php
+++ b/src/Synapse/TestHelper/InjectMockTransactionTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Synapse\TestHelper;
+
+use Synapse\Db\TransactionAwareInterface;
+
+trait InjectMockTransactionTrait
+{
+    protected $mockTransaction;
+
+    public function injectMockTransaction(TransactionAwareInterface $object)
+    {
+        $this->mockTransaction = $this->getMockBuilder('Synapse\Db\Transaction')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $object->setTransaction($this->mockTransaction);
+    }
+}


### PR DESCRIPTION
## Add TransactionAwareInterface and TransactionAwareTrait

The trait will include a setter for injecting a `Synapse\Db\Transaction` object. We'll then add an initializer to auto-inject the object.

Since it will be very common for controllers to wrap method calls in a transaction, AbstractController should implement the interface by default.

### Acceptance Criteria
- Not QA testable

### Tasks
1. Create interface
1. Create trait
1. Set up initializer
1. Have AbstractController implement the interface

### Additional Notes
- {{list additional notes here, remove if not applicable}}