### PR TITLE
LogServiceProvider causing issues on production deploy

### DIFF
--- a/src/Synapse/Log/LogServiceProvider.php
+++ b/src/Synapse/Log/LogServiceProvider.php
@@ -40,7 +40,7 @@ class LogServiceProvider implements ServiceProviderInterface
     {
         $this->config = $app['config']->load('log');
 
-        $handlers = $this->getHandlers();
+        $handlers = $this->getHandlers($app);
         $app['log'] = $app->share(function ($app) use ($handlers) {
             return new Logger('main', $handlers);
         });
@@ -68,9 +68,10 @@ class LogServiceProvider implements ServiceProviderInterface
     /**
      * Get an array of logging handlers to use
      *
+     * @param  Application $app
      * @return  array
      */
-    protected function getHandlers()
+    protected function getHandlers(Application $app)
     {
         $handlers = [];
 


### PR DESCRIPTION
## Description

`LogServiceProvider::getHandlers` function needs to be passed the `$app` reference.

```
[2015-02-10T00:29:50+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: execute[console migrations:run] (app_deploy::default line 7) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '255'
---- Begin output of ./console migrations:run ----
STDOUT: 
STDERR: PHP Warning:  Module 'newrelic' already loaded in Unknown on line 0
PHP Notice:  Undefined variable: app in /srv/www/bodetree/releases/20150210002236/api.bodetree.com/vendor/synapsestudios/synapse-base/src/Synapse/Log/LogServiceProvider.php on line 96
PHP Stack trace:
PHP   1. {main}() /srv/www/bodetree/releases/20150210002236/api.bodetree.com/console:0
PHP   2. require() /srv/www/bodetree/releases/20150210002236/api.bodetree.com/console:16
PHP   3. Synapse\Application\Services->register() /srv/www/bodetree/releases/20150210002236/api.bodetree.com/bootstrap.php:38
PHP   4. Silex\Application->register() /srv/www/bodetree/releases/20150210002236/api.bodetree.com/vendor/synapsestudios/synapse-base/src/Synapse/Application/Services.php:18
PHP   5. Synapse\Log\LogServiceProvider->register() /srv/www/bodetree/releases/20150210002236/api.bodetree.com/vendor/silex/silex/src/Silex/Application.php:169
PHP   6. Synapse\Log\LogServiceProvider->getHandlers() /srv/www/bodetree/releases/20150210002236/api.bodetree.com/vendor/synapsestudios/synapse-base/src/Synapse/Log/LogServiceProvider.php:43
 ```
## Details