### PR TITLE
Add createdDatetimeColumn and updatedDatetimeColumn to AbstractMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 CHANGELOG
 =========
 
-Upcoming Release - up to 8cf951d
+Upcoming Release - up to f502ff2
 --------------------------------
 * Add TransactionAwareInterface and TransactionAwareTrait
 * Auto-inject Transaction object into classes implementing TransactionAwareInterface
 * Have AbstractController implement TransactionAwareInterface
 * Add test helper InjectMockTransactionTrait
 * Have ControllerTestCase use InjectMockTransactionTrait
+* Add createdDatetimeColumn and updatedDatetimeColumn to AbstractMapper
+* Deprecate createdTimestampColumn and updatedTimestampColumn
 
 0.2.6 (2014-08-08)
 -----------------

--- a/src/Synapse/Mapper/AbstractMapper.php
+++ b/src/Synapse/Mapper/AbstractMapper.php
@@ -67,9 +67,24 @@ abstract class AbstractMapper implements LoggerAwareInterface
     protected $sqlFactory;
 
     /**
+     * The name of the column where a time created datetime is stored
+     *
+     * @var string
+     */
+    protected $createdDatetimeColumn = null;
+
+    /**
+     * The name of the column where a time updated datetime is stored
+     *
+     * @var string
+     */
+    protected $updatedDatetimeColumn = null;
+
+    /**
      * The name of the column where a time created timestamp is stored
      *
      * @var string
+     * @deprecated Use createdDatetimeColumn instead
      */
     protected $createdTimestampColumn = null;
 
@@ -77,6 +92,7 @@ abstract class AbstractMapper implements LoggerAwareInterface
      * The name of the column where a time updated timestamp is stored
      *
      * @var string
+     * @deprecated Use updatedDatetimeColumn instead
      */
     protected $updatedTimestampColumn = null;
 

--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -41,6 +41,12 @@ trait InserterTrait
             $values[$this->createdTimestampColumn] = $timestamp;
         }
 
+        if ($this->createdDatetimeColumn) {
+            $datetime = date('Y-m-d H:i:s');
+            $entity->exchangeArray([$this->createdDatetimeColumn => $datetime]);
+            $values[$this->createdDatetimeColumn] = $datetime;
+        }
+
         $columns = array_keys($values);
 
         $query = $this->getSqlObject()

--- a/src/Synapse/Mapper/UpdaterTrait.php
+++ b/src/Synapse/Mapper/UpdaterTrait.php
@@ -40,6 +40,12 @@ trait UpdaterTrait
             $values[$this->updatedTimestampColumn] = $timestamp;
         }
 
+        if ($this->updatedDatetimeColumn) {
+            $datetime = date('Y-m-d H:i:s');
+            $entity->exchangeArray([$this->updatedDatetimeColumn => $datetime]);
+            $values[$this->updatedDatetimeColumn] = $datetime;
+        }
+
         unset($values['id']);
 
         $condition = ['id' => $entity->getId()];

--- a/tests/Test/Synapse/Mapper/DatetimeColumnMapper.php
+++ b/tests/Test/Synapse/Mapper/DatetimeColumnMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Test\Synapse\Mapper;
+
+use Synapse\Mapper as MapperNamepace;
+
+class DatetimeColumnMapper extends MapperNamepace\AbstractMapper
+{
+    use MapperNamepace\InserterTrait;
+    use MapperNamepace\UpdaterTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $createdDatetimeColumn = 'created';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $updatedDatetimeColumn = 'updated';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $tableName = 'table_with_datetime_columns';
+}

--- a/tests/Test/Synapse/Mapper/InserterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/InserterTraitTest.php
@@ -19,6 +19,9 @@ class InserterTraitTest extends MapperTestCase
 
         $this->timestampMapper = new TimestampColumnMapper($this->mockAdapter, $this->timestampPrototype);
         $this->timestampMapper->setSqlFactory($this->mockSqlFactory);
+
+        $this->datetimeMapper = new DatetimeColumnMapper($this->mockAdapter, $this->timestampPrototype);
+        $this->datetimeMapper->setSqlFactory($this->mockSqlFactory);
     }
 
     public function createPrototype()
@@ -108,6 +111,23 @@ class InserterTraitTest extends MapperTestCase
     }
 
     public function testInsertSetsCreatedTimestampColumnAutomaticallyOnEntityAndDbQuery()
+    {
+        $entity = $this->createTimestampEntityToInsert()
+            ->setCreated(null);
+
+        $this->datetimeMapper->insert($entity);
+
+        $regexp = sprintf(
+            '/\(`id`, `foo`, `created`, `updated`\) VALUES \(NULL, \'bar\', \'%s+\', NULL\)/',
+            '(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2})' // datetime pattern
+        );
+
+        $this->assertRegExpOnSqlString($regexp);
+
+        $this->assertNotNull($entity->getCreated());
+    }
+
+    public function testInsertSetsCreatedDatetimeColumnAutomaticallyOnEntityAndDbQuery()
     {
         $entity = $this->createTimestampEntityToInsert()
             ->setCreated(null);

--- a/tests/Test/Synapse/Mapper/UpdaterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/UpdaterTraitTest.php
@@ -19,6 +19,9 @@ class UpdaterTraitTest extends MapperTestCase
 
         $this->timestampMapper = new TimestampColumnMapper($this->mockAdapter, $this->timestampPrototype);
         $this->timestampMapper->setSqlFactory($this->mockSqlFactory);
+
+        $this->datetimeMapper = new DatetimeColumnMapper($this->mockAdapter, $this->timestampPrototype);
+        $this->datetimeMapper->setSqlFactory($this->mockSqlFactory);
     }
 
     public function createPrototype()
@@ -125,6 +128,23 @@ class UpdaterTraitTest extends MapperTestCase
         $this->timestampMapper->update($entity);
 
         $regexp = sprintf('/\SET .+ `updated` = \'[0-9]+\' WHERE/');
+
+        $this->assertRegExpOnSqlString($regexp);
+
+        $this->assertNotNull($entity->getUpdated());
+    }
+
+    public function testUpdateSetsUpdatedDatetimeColumnAutomaticallyOnEntityAndDbQuery()
+    {
+        $entity = $this->createTimestampEntityToUpdate()
+            ->setUpdated(null);
+
+        $this->datetimeMapper->update($entity);
+
+        $regexp = sprintf(
+            '/\SET .+ `updated` = \'%s+\' WHERE/',
+            '(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2})' // datetime pattern
+        );
 
         $this->assertRegExpOnSqlString($regexp);
 


### PR DESCRIPTION
## Add createdDatetimeColumn and updatedDatetimeColumn to AbstractMapper

They will work the same as `createdTimestampColumn` and `updatedTimestampColumn`, only the value set will be a datetime.

### Acceptance Criteria
1. Dev Tested

### Tasks
- Add properties.
- Update InserterTrait and UpdaterTrait.
- Maybe add a comment saying the timestamp properties are deprecated.

### Additional Notes
- {{list additional notes here, remove if not applicable}}