### PR TITLE
FinderTrait::findBy supports ORDER BY options

### DIFF
--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -58,6 +58,10 @@ trait FinderTrait
 
         $this->addWheres($query, $wheres, $options);
 
+        if (Arr::get($options, 'order')) {
+            $this->setOrder($query, $options['order']);
+        }
+
         return $this->executeAndGetResultsAsEntity($query);
     }
 

--- a/tests/Test/Synapse/Mapper/FinderTraitTest.php
+++ b/tests/Test/Synapse/Mapper/FinderTraitTest.php
@@ -199,6 +199,21 @@ class FinderTraitTest extends MapperTestCase
         $this->assertRegExp($regexp, $this->getSqlString());
     }
 
+    public function testFindBySetsOrderByColumnAscendingIfOrderColumnProvidedInOptionsArray()
+    {
+        $orderColumn = 'ad9fe8c7';
+
+        $options = ['order' => [$orderColumn]];
+
+        $constraints = $this->createSearchConstraints();
+
+        $this->mapper->findBy($constraints, $options);
+
+        $regexp = sprintf('/ORDER BY `%s` ASC/', $orderColumn);
+
+        $this->assertRegExp($regexp, $this->getSqlString());
+    }
+
     /**
      * @dataProvider provideOrderDirectionValues
      */


### PR DESCRIPTION
## As a developer I can use the ORDER BY option on calls to `findBy`, because this is a totally valid thing to do in SQL

### Acceptance Criteria
1. `findBy` properly adds an `ORDER BY` statement if the `order` option is specified

### Tasks
- {{list developer tasks here}}

### Additional Notes
- {{list additional notes here, remove if not applicable}}
