### PR TITLE
Error when inserting into a table that has no `id` column

### DIFF
--- a/src/Synapse/Mapper/AbstractMapper.php
+++ b/src/Synapse/Mapper/AbstractMapper.php
@@ -104,6 +104,13 @@ abstract class AbstractMapper implements LoggerAwareInterface
     protected $primaryKey = ['id'];
 
     /**
+     * Column that auto increments. Set to null if none.
+     *
+     * @var string
+     */
+    protected $autoIncrementColumn = 'id';
+
+    /**
      * Set injected objects as properties
      *
      * @param DbAdapter      $db        Query builder object

--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -58,7 +58,8 @@ trait InserterTrait
 
         $result = $statement->execute();
 
-        if ($this->autoIncrementColumn) {
+        $entityValues = $entity->getArrayCopy();
+        if ($this->autoIncrementColumn && ! $entityValues[$this->autoIncrementColumn]) {
             $entity->exchangeArray([
                 $this->autoIncrementColumn => $result->getGeneratedValue()
             ]);

--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -58,8 +58,10 @@ trait InserterTrait
 
         $result = $statement->execute();
 
-        if (! $entity->getId()) {
-            $entity->setId($result->getGeneratedValue());
+        if ($this->autoIncrementColumn) {
+            $entity->exchangeArray([
+                $this->autoIncrementColumn => $result->getGeneratedValue()
+            ]);
         }
 
         return $entity;

--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -58,8 +58,7 @@ trait InserterTrait
 
         $result = $statement->execute();
 
-        $entityValues = $entity->getArrayCopy();
-        if ($this->autoIncrementColumn && ! $entityValues[$this->autoIncrementColumn]) {
+        if ($this->autoIncrementColumn && ! $values[$this->autoIncrementColumn]) {
             $entity->exchangeArray([
                 $this->autoIncrementColumn => $result->getGeneratedValue()
             ]);


### PR DESCRIPTION
## Error when inserting into a table that has no `id` column

### Exactly what to do

Add a property to AbstractMapper called autoIncrementColumn with default value `id`.

Change:
```php
if (! $entity->getId()) {
    $entity->setId($result->getGeneratedValue());
}
```
to:
```php
if ($this->autoIncrementColumn) {
    $entity->exchangeArray([
        $this->autoIncrementColumn => $result->getGeneratedValue()
    ]);
}
```

