### PR TITLE
Update DeleterTrait to use $primaryKey property

### DIFF
--- a/src/Synapse/Mapper/AbstractMapper.php
+++ b/src/Synapse/Mapper/AbstractMapper.php
@@ -182,6 +182,23 @@ abstract class AbstractMapper implements LoggerAwareInterface
     }
 
     /**
+     * Get a wheres array for finding the row that matches an entity
+     *
+     * @return array
+     */
+    protected function getPrimaryKeyWheres(AbstractEntity $entity)
+    {
+        $wheres = [];
+
+        $arrayCopy = $entity->getArrayCopy();
+        foreach ($this->primaryKey as $keyColumn) {
+            $wheres[$keyColumn] = $arrayCopy[$keyColumn];
+        }
+
+        return $wheres;
+    }
+
+    /**
      * Set up the hydrator and prototype of this mapper if not yet set
      */
     protected function initialize()

--- a/src/Synapse/Mapper/DeleterTrait.php
+++ b/src/Synapse/Mapper/DeleterTrait.php
@@ -17,9 +17,7 @@ trait DeleterTrait
      */
     public function delete(AbstractEntity $entity)
     {
-        return $this->deleteWhere([
-            'id' => $entity->getId()
-        ]);
+        return $this->deleteWhere($this->getPrimaryKeyWheres($entity));
     }
 
     /**

--- a/src/Synapse/Mapper/UpdaterTrait.php
+++ b/src/Synapse/Mapper/UpdaterTrait.php
@@ -46,17 +46,10 @@ trait UpdaterTrait
             $values[$this->updatedDatetimeColumn] = $datetime;
         }
 
-        $condition = [];
-        $arrayCopy = $entity->getArrayCopy();
-        foreach ($this->primaryKey as $keyColumn) {
-            unset($values[$keyColumn]);
-            $condition[$keyColumn] = $arrayCopy[$keyColumn];
-        }
-
         $query = $this->getSqlObject()
             ->update()
             ->set($values)
-            ->where($condition);
+            ->where($this->getPrimaryKeyWheres($entity));
 
         $this->execute($query);
 


### PR DESCRIPTION
## Update DeleterTrait to use $primaryKey property

Instead of assuming the existence of an `id` property, the DeleterTrait should use the `$primaryKey` property added in #177 to compose the WHERE clause.

### Acceptance Criteria
1. {{list ACs here}}

### Tasks
- {{list developer tasks here}}

### Additional Notes
- {{list additional notes here, remove if not applicable}}