### PR TITLE
Undefined index error introduced in #180

### DIFF
--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -15,10 +15,15 @@ trait InserterTrait
      *
      * @param  AbstractEntity $entity
      * @return AbstractEntity         Entity with ID populated
+     * @throws Exception              if autoIncrementColumn not in entity
      */
     public function insert(AbstractEntity $entity)
     {
         $values = $entity->getDbValues();
+
+        if ($this->autoIncrementColumn && ! array_key_exists($this->autoIncrementColumn, $values)) {
+            throw new Exception('auto_increment column ' + $this->autoIncrementColumn + ' not found');
+        }
 
         return $this->insertRow($entity, $values);
     }

--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -3,6 +3,7 @@
 namespace Synapse\Mapper;
 
 use Synapse\Entity\AbstractEntity;
+use Synapse\Stdlib\Arr;
 
 /**
  * Use this trait to add create functionality to AbstractMappers.
@@ -58,7 +59,7 @@ trait InserterTrait
 
         $result = $statement->execute();
 
-        if ($this->autoIncrementColumn && ! $values[$this->autoIncrementColumn]) {
+        if ($this->autoIncrementColumn && ! Arr::get($values, $this->autoIncrementColumn)) {
             $entity->exchangeArray([
                 $this->autoIncrementColumn => $result->getGeneratedValue()
             ]);

--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -3,7 +3,6 @@
 namespace Synapse\Mapper;
 
 use Synapse\Entity\AbstractEntity;
-use Synapse\Stdlib\Arr;
 
 /**
  * Use this trait to add create functionality to AbstractMappers.
@@ -64,7 +63,7 @@ trait InserterTrait
 
         $result = $statement->execute();
 
-        if ($this->autoIncrementColumn && ! Arr::get($values, $this->autoIncrementColumn)) {
+        if ($this->autoIncrementColumn && ! $values[$this->autoIncrementColumn]) {
             $entity->exchangeArray([
                 $this->autoIncrementColumn => $result->getGeneratedValue()
             ]);

--- a/tests/Test/Synapse/Mapper/InserterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/InserterTraitTest.php
@@ -22,6 +22,12 @@ class InserterTraitTest extends MapperTestCase
 
         $this->datetimeMapper = new DatetimeColumnMapper($this->mockAdapter, $this->timestampPrototype);
         $this->datetimeMapper->setSqlFactory($this->mockSqlFactory);
+
+        $this->invalidAutoincrementMapper = new InvalidAutoincrementMapper(
+            $this->mockAdapter,
+            $this->timestampPrototype
+        );
+        $this->invalidAutoincrementMapper->setSqlFactory($this->mockSqlFactory);
     }
 
     public function createPrototype()
@@ -160,5 +166,14 @@ class InserterTraitTest extends MapperTestCase
         $this->mapper->insert($entity);
 
         $this->assertEquals($expectedId, $entity->getId());
+    }
+
+    public function testInsertDoesNotCauseAnErrorIfAutoincrementColumnNotInEntity()
+    {
+        $entity = $this->createEntityToInsert();
+
+        $this->invalidAutoincrementMapper->insert($entity);
+
+        $this->assertNull($entity->getId());
     }
 }

--- a/tests/Test/Synapse/Mapper/InserterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/InserterTraitTest.php
@@ -168,12 +168,12 @@ class InserterTraitTest extends MapperTestCase
         $this->assertEquals($expectedId, $entity->getId());
     }
 
-    public function testInsertDoesNotCauseAnErrorIfAutoincrementColumnNotInEntity()
+    public function testInsertThrowsExceptionIfAutoincrementColumnNotInEntity()
     {
+        $this->setExpectedException('Synapse\Mapper\Exception');
+
         $entity = $this->createEntityToInsert();
 
         $this->invalidAutoincrementMapper->insert($entity);
-
-        $this->assertNull($entity->getId());
     }
 }

--- a/tests/Test/Synapse/Mapper/InvalidAutoincrementMapper.php
+++ b/tests/Test/Synapse/Mapper/InvalidAutoincrementMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Test\Synapse\Mapper;
+
+use Synapse\Mapper as MapperNamespace;
+
+/**
+ * Generic mapper for testing
+ */
+class InvalidAutoincrementMapper extends MapperNamespace\AbstractMapper
+{
+    use MapperNamespace\FinderTrait;
+    use MapperNamespace\InserterTrait;
+    use MapperNamespace\UpdaterTrait;
+    use MapperNamespace\DeleterTrait;
+
+    const OTHER_TABLE = 'other_table';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $tableName = 'test_table';
+
+    protected $autoIncrementColumn = 'not_a_real_column';
+}


### PR DESCRIPTION
## Undefined index error introduced in #180

Error occurs if your entity has no `id` property and you forget to change the $autoIncrementColumn value