### PR TITLE
Add bind() values to OAuth server routes

### DIFF
--- a/src/Synapse/OAuth2/ServerServiceProvider.php
+++ b/src/Synapse/OAuth2/ServerServiceProvider.php
@@ -87,12 +87,17 @@ class ServerServiceProvider implements ServiceProviderInterface
         $this->setup($app);
         $this->setFirewalls($app);
 
-        $app->get('/oauth/authorize', 'oauth.controller:authorize');
+        $app->get('/oauth/authorize', 'oauth.controller:authorize')
+            ->bind('oauth-authorize');
+
         $app->post('/oauth/authorize-submit', 'oauth.controller:authorizeFormSubmit')
             ->bind('oauth-authorize-form-submit');
 
-        $app->post('/oauth/token', 'oauth.controller:token');
-        $app->post('/oauth/logout', 'oauth.controller:logout');
+        $app->post('/oauth/token', 'oauth.controller:token')
+            ->bind('oauth-token');
+
+        $app->post('/oauth/logout', 'oauth.controller:logout')
+            ->bind('oauth-logout');
     }
 
     /**


### PR DESCRIPTION
## Add bind() values to OAuth server routes

In order to overwrite a route you have to use `bind()` values on the route that is being overwritten. So in order to make the OAuth routes overwrite-able `bind()` values need to be set.

### Acceptance Criteria
1. routes in the `Oauth2\ServerServiceProvider` have bind values