### PR TITLE
Create SecurityContextMockInjector trait

### DIFF
--- a/src/Synapse/TestHelper/AbstractSecurityAwareTestCase.php
+++ b/src/Synapse/TestHelper/AbstractSecurityAwareTestCase.php
@@ -3,93 +3,17 @@
 namespace Synapse\TestHelper;
 
 use PHPUnit_Framework_TestCase;
-use Synapse\User\UserEntity;
-use stdClass;
 
 /**
  * Extend this class to create mocks of the security token and context for testing
+ * @deprecated - use SecurityContextMockInjector instead
  */
 abstract class AbstractSecurityAwareTestCase extends PHPUnit_Framework_TestCase
 {
+    use SecurityContextMockInjector;
+
+    /**
+     * @deprecated - use the static $loggedInUserId in SecurityContextMockInjector
+     */
     const LOGGED_IN_USER_ID = 42;
-
-    /**
-     * @var mixed  UserEntity or null to simulate the user not being logged in
-     */
-    protected $loggedInUserEntity = false;
-
-    /**
-     * Set up the mock security context
-     *
-     * `getToken` returns a mocked security token whose getUser method returns a UserEntity.
-     * Customize the user returned by overloading getDefaultLoggedInUserEntity.
-     */
-    public function setUpMockSecurityContext()
-    {
-        if (! isset($this->captured)) {
-            $this->captured = new stdClass();
-        }
-
-        $this->mockSecurityContext = $this->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockSecurityToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-
-        $mockSecurityToken->expects($this->any())
-            ->method('getUser')
-            ->will($this->returnCallback(function () {
-                $this->captured->userReturnedFromSecurityContext = $this->getLoggedInUserEntity();
-                return $this->captured->userReturnedFromSecurityContext;
-            }));
-
-        $this->mockSecurityContext->expects($this->any())
-            ->method('getToken')
-            ->will($this->returnValue($mockSecurityToken));
-    }
-
-    /**
-     * Return a Mocked UserEntity object
-     *
-     * @return UserEntity
-     */
-    public function getDefaultLoggedInUserEntity()
-    {
-        $user = new UserEntity;
-
-        $user->exchangeArray([
-            'id'         => self::LOGGED_IN_USER_ID,
-            'email'      => 'test@example.com',
-            'password'   => 'password',
-            'last_login' => 1397078025,
-            'created'    => 1397077825,
-            'enabled'    => 1,
-            'verified'   => 1,
-        ]);
-
-        return $user;
-    }
-
-    /**
-     * Return a User entity for use with the mock security object
-     *
-     * @return UserEntity or null
-     */
-    public function getLoggedInUserEntity()
-    {
-        // If not changed from initial value, return default.
-        if ($this->loggedInUserEntity === false) {
-            $this->loggedInUserEntity = $this->getDefaultLoggedInUserEntity();
-        }
-
-        return $this->loggedInUserEntity;
-    }
-
-    /**
-     * @param mixed $user  UserEntity or null to simulate the user not being logged in
-     */
-    public function setLoggedInUserEntity($user)
-    {
-        $this->loggedInUserEntity = $user;
-    }
 }

--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -7,13 +7,13 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolation;
 use Synapse\Controller\AbstractController;
 use Synapse\Stdlib\Arr;
-use Synapse\TestHelper\TransactionTraitMockInjector;
+use Synapse\TestHelper\TransactionMockInjector;
 use Synapse\User\UserEntity;
 use stdClass;
 
 abstract class ControllerTestCase extends AbstractSecurityAwareTestCase
 {
-    use TransactionTraitMockInjector;
+    use TransactionMockInjector;
 
     public function createJsonRequest($method, array $params = [])
     {

--- a/src/Synapse/TestHelper/ControllerTestCase.php
+++ b/src/Synapse/TestHelper/ControllerTestCase.php
@@ -7,13 +7,13 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolation;
 use Synapse\Controller\AbstractController;
 use Synapse\Stdlib\Arr;
-use Synapse\TestHelper\InjectMockTransactionTrait;
+use Synapse\TestHelper\TransactionTraitMockInjector;
 use Synapse\User\UserEntity;
 use stdClass;
 
 abstract class ControllerTestCase extends AbstractSecurityAwareTestCase
 {
-    use InjectMockTransactionTrait;
+    use TransactionTraitMockInjector;
 
     public function createJsonRequest($method, array $params = [])
     {

--- a/src/Synapse/TestHelper/SecurityContextMockInjector.php
+++ b/src/Synapse/TestHelper/SecurityContextMockInjector.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Synapse\TestHelper;
+
+use Synapse\User\UserEntity;
+use stdClass;
+
+trait SecurityContextMockInjector
+{
+    protected static $loggedInUserId = 42;
+
+    /**
+     * @var mixed  UserEntity or null to simulate the user not being logged in
+     */
+    protected $loggedInUserEntity = false;
+
+    /**
+     * Set up the mock security context
+     *
+     * `getToken` returns a mocked security token whose getUser method returns a UserEntity.
+     * Customize the user returned by overloading getDefaultLoggedInUserEntity.
+     */
+    public function setUpMockSecurityContext()
+    {
+        if (! isset($this->captured)) {
+            $this->captured = new stdClass();
+        }
+
+        $this->mockSecurityContext = $this->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockSecurityToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+
+        $mockSecurityToken->expects($this->any())
+            ->method('getUser')
+            ->will($this->returnCallback(function () {
+                $this->captured->userReturnedFromSecurityContext = $this->getLoggedInUserEntity();
+                return $this->captured->userReturnedFromSecurityContext;
+            }));
+
+        $this->mockSecurityContext->expects($this->any())
+            ->method('getToken')
+            ->will($this->returnValue($mockSecurityToken));
+    }
+
+    /**
+     * Return a Mocked UserEntity object
+     *
+     * @return UserEntity
+     */
+    public function getDefaultLoggedInUserEntity()
+    {
+        $user = new UserEntity;
+
+        $user->exchangeArray([
+            'id'         => self::$loggedInUserId,
+            'email'      => 'test@example.com',
+            'password'   => 'password',
+            'last_login' => 1397078025,
+            'created'    => 1397077825,
+            'enabled'    => 1,
+            'verified'   => 1,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * Return a User entity for use with the mock security object
+     *
+     * @return UserEntity or null
+     */
+    public function getLoggedInUserEntity()
+    {
+        // If not changed from initial value, return default.
+        if ($this->loggedInUserEntity === false) {
+            $this->loggedInUserEntity = $this->getDefaultLoggedInUserEntity();
+        }
+
+        return $this->loggedInUserEntity;
+    }
+
+    /**
+     * @param mixed $user  UserEntity or null to simulate the user not being logged in
+     */
+    public function setLoggedInUserEntity($user)
+    {
+        $this->loggedInUserEntity = $user;
+    }
+}

--- a/src/Synapse/TestHelper/TransactionMockInjector.php
+++ b/src/Synapse/TestHelper/TransactionMockInjector.php
@@ -4,7 +4,7 @@ namespace Synapse\TestHelper;
 
 use Synapse\Db\TransactionAwareInterface;
 
-trait TransactionTraitMockInjector
+trait TransactionMockInjector
 {
     protected $mockTransaction;
 

--- a/src/Synapse/TestHelper/TransactionTraitMockInjector.php
+++ b/src/Synapse/TestHelper/TransactionTraitMockInjector.php
@@ -4,7 +4,7 @@ namespace Synapse\TestHelper;
 
 use Synapse\Db\TransactionAwareInterface;
 
-trait InjectMockTransactionTrait
+trait TransactionTraitMockInjector
 {
     protected $mockTransaction;
 


### PR DESCRIPTION
## Create `SecurityContextMockInjector` trait

### Acceptance Criteria
1. `SecurityContextMockInjector` trait exists with all the same functionality of `AbstractSecurityAwareTestCase`.
1. Use `SecurityContextMockInjector` trait in `AbstractSecurityAwareTestCase` and delete the properties and methods in `AbstractSecurityAwareTestCase`. Mark `AbstractSecurityAwareTestCase` as deprecated.
1. Rename `InjectMockTransactionTrait` to `TransactionMockInjector`
