### PR TITLE
Allow RowExists, RowsExist, and RowNotExists constraints to match on custom field names

### DIFF
--- a/src/Synapse/Validator/Constraints/RowExists.php
+++ b/src/Synapse/Validator/Constraints/RowExists.php
@@ -11,8 +11,9 @@ use LogicException;
  */
 class RowExists extends Constraint
 {
-    public $message = 'Entity must exist with {{ field }} field equal to {{ value }}.';
-    public $field   = 'id';
+    public $message        = 'Entity must exist with {{ field }} field equal to {{ value }}.';
+    public $field          = 'id';
+    public $filterCallback = null;
 
     /**
      * Mapper to use to search for entity
@@ -27,6 +28,18 @@ class RowExists extends Constraint
      */
     public function __construct(AbstractMapper $mapper, $options = null)
     {
+        if (isset($options['filterCallback']) && isset($options['field'])) {
+            throw new LogicException('filterCallback and field are both set. Only one is expected.');
+        }
+
+        if (isset($options['field'])) {
+            $options['filterCallback'] = function ($value) use ($options) {
+                return [
+                    $options['field'] => $value
+                ];
+            };
+        }
+
         if (! method_exists($mapper, 'findBy')) {
             $message = sprintf(
                 'Mapper injected into %s must use FinderTrait',

--- a/src/Synapse/Validator/Constraints/RowExists.php
+++ b/src/Synapse/Validator/Constraints/RowExists.php
@@ -11,9 +11,16 @@ use LogicException;
  */
 class RowExists extends Constraint
 {
-    public $message        = 'Entity must exist with {{ field }} field equal to {{ value }}.';
-    public $field          = 'id';
+    public $message        = 'Entity must exist with specified parameters.';
     public $filterCallback = null;
+    public $field          = 'id';
+
+    /**
+     * Message to use if we're using the 'field' option
+     *
+     * @var string
+     */
+    protected $fieldMessage = 'Entity must exist with {{ field }} field equal to {{ value }}.';
 
     /**
      * Mapper to use to search for entity
@@ -38,6 +45,7 @@ class RowExists extends Constraint
                     $options['field'] => $value
                 ];
             };
+            $this->message = $this->fieldMessage;
         }
 
         if (! method_exists($mapper, 'findBy')) {

--- a/src/Synapse/Validator/Constraints/RowExistsValidator.php
+++ b/src/Synapse/Validator/Constraints/RowExistsValidator.php
@@ -18,9 +18,8 @@ class RowExistsValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        $entity = $constraint->getMapper()->findBy([
-            $constraint->field => $value
-        ]);
+        $callback = $constraint->filterCallback;
+        $entity = $constraint->getMapper()->findBy($callback($value));
 
         if ($entity instanceof AbstractEntity) {
             return;

--- a/src/Synapse/Validator/Constraints/RowNotExists.php
+++ b/src/Synapse/Validator/Constraints/RowNotExists.php
@@ -7,5 +7,6 @@ namespace Synapse\Validator\Constraints;
  */
 class RowNotExists extends RowExists
 {
-    public $message = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
+    public $message = 'Entity must not exist with specified parameters.';
+    protected $fieldMessage = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
 }

--- a/src/Synapse/Validator/Constraints/RowNotExistsValidator.php
+++ b/src/Synapse/Validator/Constraints/RowNotExistsValidator.php
@@ -18,9 +18,8 @@ class RowNotExistsValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        $entity = $constraint->getMapper()->findBy([
-            $constraint->field => $value
-        ]);
+        $callback = $constraint->filterCallback;
+        $entity = $constraint->getMapper()->findBy($callback($value));
 
         if (! $entity instanceof AbstractEntity) {
             return;

--- a/tests/Test/Synapse/Validator/Constraints/RowExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowExistsValidatorTest.php
@@ -8,6 +8,8 @@ use Test\Synapse\Entity\GenericEntity;
 
 class RowExistsValidatorTest extends ValidatorConstraintTestCase
 {
+    const MESSAGE = 'Entity must exist with {{ field }} field equal to {{ value }}.';
+
     public function setUp()
     {
         $this->validator = new RowExistsValidator;
@@ -87,6 +89,7 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
 
         $this->withEntityNotFound();
         $this->withFilterCallbackReturningWheres();
+        $this->mockConstraint->message = self::MESSAGE;
 
         $this->validateWithValue($value);
 
@@ -96,7 +99,7 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
         ];
 
         $this->assertViolationAdded(
-            'Entity must exist with {{ field }} field equal to {{ value }}.',
+            self::MESSAGE,
             $params,
             $value
         );

--- a/tests/Test/Synapse/Validator/Constraints/RowExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowExistsValidatorTest.php
@@ -36,6 +36,13 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
             ->will($this->returnValue($this->mockMapper));
     }
 
+    public function withFilterCallbackReturningWheres($wheres = [])
+    {
+        $this->mockConstraint->filterCallback = function () use ($wheres) {
+            return $wheres;
+        };
+    }
+
     public function withEntityFound()
     {
         $entity = new GenericEntity;
@@ -52,10 +59,8 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
             ->will($this->returnValue(false));
     }
 
-    public function expectingEntitySearchedForWithFieldAndValue($field, $value)
+    public function expectingEntitySearchedForWithWheres($wheres)
     {
-        $wheres = [$field => $value];
-
         $this->mockMapper->expects($this->once())
             ->method('findBy')
             ->with($this->equalTo($wheres));
@@ -69,6 +74,7 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
     public function testValidateAddsNoViolationsIfEntityFound()
     {
         $this->withEntityFound();
+        $this->withFilterCallbackReturningWheres();
 
         $this->validateWithValue('foo');
 
@@ -80,6 +86,7 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
         $value = 'foo';
 
         $this->withEntityNotFound();
+        $this->withFilterCallbackReturningWheres();
 
         $this->validateWithValue($value);
 
@@ -100,9 +107,10 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
         $field = 'foo';
         $value = 'bar';
 
-        $this->mockConstraint->field = $field;
+        $wheres = ['x' => 'y'];
+        $this->withFilterCallbackReturningWheres($wheres);
 
-        $this->expectingEntitySearchedForWithFieldAndValue($field, $value);
+        $this->expectingEntitySearchedForWithWheres($wheres);
 
         $this->validateWithValue($value);
     }

--- a/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
@@ -8,6 +8,8 @@ use Test\Synapse\Entity\GenericEntity;
 
 class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
 {
+    const MESSAGE = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
+
     public function setUp()
     {
         $this->validator = new RowNotExistsValidator;
@@ -87,6 +89,7 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
 
         $this->withEntityFound();
         $this->withFilterCallbackReturningWheres();
+        $this->mockConstraint->message = self::MESSAGE;
 
         $this->validateWithValue($value);
 
@@ -96,7 +99,7 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
         ];
 
         $this->assertViolationAdded(
-            'Entity must not exist with {{ field }} field equal to {{ value }}.',
+            self::MESSAGE,
             $params,
             $value
         );

--- a/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
@@ -36,6 +36,13 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
             ->will($this->returnValue($this->mockMapper));
     }
 
+    public function withFilterCallbackReturningWheres($wheres = [])
+    {
+        $this->mockConstraint->filterCallback = function () use ($wheres) {
+            return $wheres;
+        };
+    }
+
     public function withEntityFound()
     {
         $entity = new GenericEntity;
@@ -52,10 +59,8 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
             ->will($this->returnValue(false));
     }
 
-    public function expectingEntitySearchedForWithFieldAndValue($field, $value)
+    public function expectingEntitySearchedForWithWheres($wheres)
     {
-        $wheres = [$field => $value];
-
         $this->mockMapper->expects($this->once())
             ->method('findBy')
             ->with($this->equalTo($wheres));
@@ -69,6 +74,7 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
     public function testValidateAddsNoViolationsIfEntityNotFound()
     {
         $this->withEntityNotFound();
+        $this->withFilterCallbackReturningWheres();
 
         $this->validateWithValue('foo');
 
@@ -80,6 +86,7 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
         $value = 'foo';
 
         $this->withEntityFound();
+        $this->withFilterCallbackReturningWheres();
 
         $this->validateWithValue($value);
 
@@ -100,9 +107,10 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
         $field = 'foo';
         $value = 'bar';
 
-        $this->mockConstraint->field = $field;
+        $wheres = ['x' => 'y'];
+        $this->withFilterCallbackReturningWheres($wheres);
 
-        $this->expectingEntitySearchedForWithFieldAndValue($field, $value);
+        $this->expectingEntitySearchedForWithWheres($wheres);
 
         $this->validateWithValue($value);
     }

--- a/tests/Test/Synapse/Validator/Constraints/RowsExistValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowsExistValidatorTest.php
@@ -8,6 +8,8 @@ use Test\Synapse\Entity\GenericEntity;
 
 class RowsExistValidatorTest extends ValidatorConstraintTestCase
 {
+    const MESSAGE = 'Entity must exist with {{ field }} field equal to {{ value }}.';
+
     public function setUp()
     {
         $this->validator = new RowsExistValidator;
@@ -86,6 +88,7 @@ class RowsExistValidatorTest extends ValidatorConstraintTestCase
 
         $this->withEntityNotFound();
         $this->withFilterCallbackReturningWheres();
+        $this->mockConstraint->message = self::MESSAGE;
 
         $this->validateWithValues($values);
 
@@ -100,7 +103,7 @@ class RowsExistValidatorTest extends ValidatorConstraintTestCase
 
         foreach ($values as $key => $value) {
             $this->assertViolationAdded(
-                'Entity must exist with {{ field }} field equal to {{ value }}.',
+                self::MESSAGE,
                 $params[$key],
                 $value
             );


### PR DESCRIPTION
## Allow RowExists, RowsExist, and RowNotExists constraints to match on custom field names

### Acceptance Criteria
1. For each of those constraints, the default `id` field can be overridden with the `field` option, so that they become checks that "an entity exists with {{ this field }} equal to the given value".
1. Another `additional_fields` option exists which filters the constraint to only look for entities which also contain the given fields with the given values.
1. If `additional_fields` contains the contains a key equal to `field` (or the default field `id` if not provided) an Exception is thrown.

### Tasks
- Modify the three mentioned constraints.
- Test them?