### PR TITLE
Data Object: Add support for fluent interface in setAs* methods

### DIFF
--- a/src/Synapse/Stdlib/DataObject.php
+++ b/src/Synapse/Stdlib/DataObject.php
@@ -4,6 +4,7 @@ namespace Synapse\Stdlib;
 
 use BadMethodCallException;
 use InvalidArgumentException;
+use Synapse\Entity\AbstractEntity;
 use Zend\Stdlib\ArraySerializableInterface;
 
 abstract class DataObject implements ArraySerializableInterface
@@ -148,10 +149,14 @@ abstract class DataObject implements ArraySerializableInterface
      *
      * @param string $field Field to set
      * @param mixed  $value Value to set
+     *
+     * @return $this
      */
     protected function setAsInteger($field, $value)
     {
         $this->object[$field] = (int) $value;
+
+        return $this;
     }
 
     /**
@@ -159,10 +164,14 @@ abstract class DataObject implements ArraySerializableInterface
      *
      * @param string $field Field to set
      * @param mixed  $value Value to set
+     *
+     * @return $this
      */
     protected function setAsFloat($field, $value)
     {
         $this->object[$field] = (float) $value;
+
+        return $this;
     }
 
     /**
@@ -170,10 +179,14 @@ abstract class DataObject implements ArraySerializableInterface
      *
      * @param string $field Field to set
      * @param mixed  $value Value to set
+     *
+     * @return $this
      */
     protected function setAsBoolean($field, $value)
     {
         $this->object[$field] = (bool) $value;
+
+        return $this;
     }
 
     /**
@@ -181,9 +194,13 @@ abstract class DataObject implements ArraySerializableInterface
      *
      * @param string $field Field to set
      * @param mixed  $value Value to set
+     *
+     * @return $this
      */
     protected function setAsString($field, $value)
     {
         $this->object[$field] = (string) $value;
+
+        return $this;
     }
 }


### PR DESCRIPTION
## Data Object: Add support for fluent interface in setAs* methods, so that they match the magic setters

### Acceptance Criteria
1. In `DataObject` the `setAsInteger`, `setAsBoolean`, and `setAsString` methods all `return $this;` at the end.

### Tasks
- Add `return $this;` to end of said methods.

### Additional Notes
- Just realized they don't match the magic setters...that's all.