### PR TITLE
RowExists breaks if trying to default to Field ID

### DIFF
--- a/src/Synapse/Validator/Constraints/RowExistsValidator.php
+++ b/src/Synapse/Validator/Constraints/RowExistsValidator.php
@@ -18,8 +18,8 @@ class RowExistsValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        $callback = $constraint->filterCallback;
-        $entity = $constraint->getMapper()->findBy($callback($value));
+        $callback = $constraint->getFilterCallback();
+        $entity   = $constraint->getMapper()->findBy($callback($value));
 
         if ($entity instanceof AbstractEntity) {
             return;

--- a/src/Synapse/Validator/Constraints/RowNotExists.php
+++ b/src/Synapse/Validator/Constraints/RowNotExists.php
@@ -7,6 +7,15 @@ namespace Synapse\Validator\Constraints;
  */
 class RowNotExists extends RowExists
 {
+    /**
+     * Message to use if we're using the 'field' option
+     *
+     * @var string
+     */
+    const FIELD_MESSAGE = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
+
+    /**
+     * {@inheritdoc}
+     */
     public $message = 'Entity must not exist with specified parameters.';
-    protected $fieldMessage = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
 }

--- a/src/Synapse/Validator/Constraints/RowNotExistsValidator.php
+++ b/src/Synapse/Validator/Constraints/RowNotExistsValidator.php
@@ -18,8 +18,8 @@ class RowNotExistsValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        $callback = $constraint->filterCallback;
-        $entity = $constraint->getMapper()->findBy($callback($value));
+        $callback = $constraint->getFilterCallback();
+        $entity   = $constraint->getMapper()->findBy($callback($value));
 
         if (! $entity instanceof AbstractEntity) {
             return;

--- a/tests/Test/Synapse/Validator/Constraints/AbstractRowExistsTestCase.php
+++ b/tests/Test/Synapse/Validator/Constraints/AbstractRowExistsTestCase.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Test\Synapse\Validator\Constraints;
+
+use Synapse\TestHelper\ValidatorConstraintTestCase;
+use Test\Synapse\Entity\GenericEntity;
+
+abstract class AbstractRowExistsTestCase extends ValidatorConstraintTestCase
+{
+    public function setUp()
+    {
+        $this->setUpMocksOnValidator($this->validator);
+        $this->setUpMockConstraint();
+        $this->setUpMapperInMockConstraint();
+    }
+
+    public function setUpMockConstraint()
+    {
+        $this->mockConstraint = $this->getMockBuilder('Synapse\Validator\Constraints\RowNotExists')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function setUpMapperInMockConstraint()
+    {
+        $this->mockMapper = $this->getMockBuilder('Test\Synapse\Mapper\Mapper')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockConstraint->expects($this->any())
+            ->method('getMapper')
+            ->will($this->returnValue($this->mockMapper));
+    }
+
+    public function withFilterCallbackReturningWheres($wheres = [])
+    {
+        $callback = function () use ($wheres) {
+            return $wheres;
+        };
+
+        $this->mockConstraint->expects($this->any())
+            ->method('getFilterCallback')
+            ->will($this->returnValue($callback));
+    }
+
+    public function withEntityFound()
+    {
+        $entity = new GenericEntity;
+
+        $this->mockMapper->expects($this->any())
+            ->method('findBy')
+            ->will($this->returnValue($entity));
+    }
+
+    public function withEntityNotFound()
+    {
+        $this->mockMapper->expects($this->any())
+            ->method('findBy')
+            ->will($this->returnValue(false));
+    }
+
+    public function expectingEntitySearchedForWithWheres($wheres)
+    {
+        $this->mockMapper->expects($this->once())
+            ->method('findBy')
+            ->with($this->equalTo($wheres));
+    }
+
+    public function validateWithValue($value)
+    {
+        return $this->validator->validate($value, $this->mockConstraint);
+    }
+}

--- a/tests/Test/Synapse/Validator/Constraints/RowExistsTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowExistsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Test\Synapse\Validator\Constraints;
+
+use PHPUnit_Framework_TestCase;
+use Synapse\Validator\Constraints\RowExists;
+
+class RowExistsTest extends PHPUnit_Framework_TestCase
+{
+    public function __construct()
+    {
+        $this->mockMapper = $this->getMockBuilder('Test\Synapse\Mapper\Mapper')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testFilterCallbackIsCreatedEvenIfNoFieldOrCallbackProvided()
+    {
+        $constraint = new RowExists($this->mockMapper);
+
+        $this->assertNotNull($constraint->getFilterCallback());
+    }
+}

--- a/tests/Test/Synapse/Validator/Constraints/RowExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowExistsValidatorTest.php
@@ -2,11 +2,9 @@
 
 namespace Test\Synapse\Validator\Constraints;
 
-use Synapse\TestHelper\ValidatorConstraintTestCase;
 use Synapse\Validator\Constraints\RowExistsValidator;
-use Test\Synapse\Entity\GenericEntity;
 
-class RowExistsValidatorTest extends ValidatorConstraintTestCase
+class RowExistsValidatorTest extends AbstractRowExistsTestCase
 {
     const MESSAGE = 'Entity must exist with {{ field }} field equal to {{ value }}.';
 
@@ -14,72 +12,14 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
     {
         $this->validator = new RowExistsValidator;
 
-        $this->setUpMocksOnValidator($this->validator);
-        $this->setUpMockConstraint();
-
-        $this->setUpMapperInMockConstraint();
-    }
-
-    public function setUpMockConstraint()
-    {
-        $this->mockConstraint = $this->getMockBuilder('Synapse\Validator\Constraints\RowExists')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
-    public function setUpMapperInMockConstraint()
-    {
-        $this->mockMapper = $this->getMockBuilder('Test\Synapse\Mapper\Mapper')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->mockConstraint->expects($this->any())
-            ->method('getMapper')
-            ->will($this->returnValue($this->mockMapper));
-    }
-
-    public function withFilterCallbackReturningWheres($wheres = [])
-    {
-        $this->mockConstraint->filterCallback = function () use ($wheres) {
-            return $wheres;
-        };
-    }
-
-    public function withEntityFound()
-    {
-        $entity = new GenericEntity;
-
-        $this->mockMapper->expects($this->any())
-            ->method('findBy')
-            ->will($this->returnValue($entity));
-    }
-
-    public function withEntityNotFound()
-    {
-        $this->mockMapper->expects($this->any())
-            ->method('findBy')
-            ->will($this->returnValue(false));
-    }
-
-    public function expectingEntitySearchedForWithWheres($wheres)
-    {
-        $this->mockMapper->expects($this->once())
-            ->method('findBy')
-            ->with($this->equalTo($wheres));
-    }
-
-    public function validateWithValue($value)
-    {
-        return $this->validator->validate($value, $this->mockConstraint);
+        parent::setUp();
     }
 
     public function testValidateAddsNoViolationsIfEntityFound()
     {
         $this->withEntityFound();
         $this->withFilterCallbackReturningWheres();
-
         $this->validateWithValue('foo');
-
         $this->assertNoViolationsAdded();
     }
 
@@ -103,18 +43,5 @@ class RowExistsValidatorTest extends ValidatorConstraintTestCase
             $params,
             $value
         );
-    }
-
-    public function testValidateSearchesForEntityByFieldSetInConstraint()
-    {
-        $field = 'foo';
-        $value = 'bar';
-
-        $wheres = ['x' => 'y'];
-        $this->withFilterCallbackReturningWheres($wheres);
-
-        $this->expectingEntitySearchedForWithWheres($wheres);
-
-        $this->validateWithValue($value);
     }
 }

--- a/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowNotExistsValidatorTest.php
@@ -2,11 +2,9 @@
 
 namespace Test\Synapse\Validator\Constraints;
 
-use Synapse\TestHelper\ValidatorConstraintTestCase;
 use Synapse\Validator\Constraints\RowNotExistsValidator;
-use Test\Synapse\Entity\GenericEntity;
 
-class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
+class RowNotExistsValidatorTest extends AbstractRowExistsTestCase
 {
     const MESSAGE = 'Entity must not exist with {{ field }} field equal to {{ value }}.';
 
@@ -14,72 +12,14 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
     {
         $this->validator = new RowNotExistsValidator;
 
-        $this->setUpMocksOnValidator($this->validator);
-        $this->setUpMockConstraint();
-
-        $this->setUpMapperInMockConstraint();
-    }
-
-    public function setUpMockConstraint()
-    {
-        $this->mockConstraint = $this->getMockBuilder('Synapse\Validator\Constraints\RowNotExists')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
-    public function setUpMapperInMockConstraint()
-    {
-        $this->mockMapper = $this->getMockBuilder('Test\Synapse\Mapper\Mapper')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->mockConstraint->expects($this->any())
-            ->method('getMapper')
-            ->will($this->returnValue($this->mockMapper));
-    }
-
-    public function withFilterCallbackReturningWheres($wheres = [])
-    {
-        $this->mockConstraint->filterCallback = function () use ($wheres) {
-            return $wheres;
-        };
-    }
-
-    public function withEntityFound()
-    {
-        $entity = new GenericEntity;
-
-        $this->mockMapper->expects($this->any())
-            ->method('findBy')
-            ->will($this->returnValue($entity));
-    }
-
-    public function withEntityNotFound()
-    {
-        $this->mockMapper->expects($this->any())
-            ->method('findBy')
-            ->will($this->returnValue(false));
-    }
-
-    public function expectingEntitySearchedForWithWheres($wheres)
-    {
-        $this->mockMapper->expects($this->once())
-            ->method('findBy')
-            ->with($this->equalTo($wheres));
-    }
-
-    public function validateWithValue($value)
-    {
-        return $this->validator->validate($value, $this->mockConstraint);
+        parent::setUp();
     }
 
     public function testValidateAddsNoViolationsIfEntityNotFound()
     {
         $this->withEntityNotFound();
         $this->withFilterCallbackReturningWheres();
-
         $this->validateWithValue('foo');
-
         $this->assertNoViolationsAdded();
     }
 
@@ -103,18 +43,5 @@ class RowNotExistsValidatorTest extends ValidatorConstraintTestCase
             $params,
             $value
         );
-    }
-
-    public function testValidateSearchesForEntityByFieldSetInConstraint()
-    {
-        $field = 'foo';
-        $value = 'bar';
-
-        $wheres = ['x' => 'y'];
-        $this->withFilterCallbackReturningWheres($wheres);
-
-        $this->expectingEntitySearchedForWithWheres($wheres);
-
-        $this->validateWithValue($value);
     }
 }


### PR DESCRIPTION
## Description

In #142, RowExists (and family) were made more flexible by allowing custom `$wheres` via a callback or custom field.

However, the case was not provided for where no `field` or `filterCallback` are specified. (Meaning the developer intends for the default `id` field to be used.)