### PR TITLE
Facilitate testing of time-related logic with TimeAwareInterface

### DIFF
--- a/src/Synapse/Application/Services.php
+++ b/src/Synapse/Application/Services.php
@@ -45,6 +45,7 @@ class Services implements ServicesInterface
         $app->register(new \Synapse\Security\SecurityServiceProvider);
         $app->register(new \Synapse\Session\SessionServiceProvider);
         $app->register(new \Synapse\SocialLogin\SocialLoginServiceProvider);
+        $app->register(new \Synapse\Time\TimeServiceProvider);
         $app->register(new \Synapse\Validator\ValidatorServiceProvider);
 
         $app->register(new \Synapse\View\ViewServiceProvider, [

--- a/src/Synapse/TestHelper/TimeMockInjector.php
+++ b/src/Synapse/TestHelper/TimeMockInjector.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\TestHelper;
+
+use Synapse\Time\TimeAwareInterface;
+
+trait TimeMockInjector
+{
+    public function injectMockTimeObject(TimeAwareInterface $injectee)
+    {
+        $this->mocks['time'] = $this->getMock('Synapse\Time\Time');
+
+        $injectee->setTimeObject($this->mocks['time']);
+    }
+}

--- a/src/Synapse/Time/Time.php
+++ b/src/Synapse/Time/Time.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Synapse\Time;
+
+class Time
+{
+    public function date()
+    {
+        return call_user_func_array('date', func_get_args());
+    }
+
+    public function time()
+    {
+        return time();
+    }
+}

--- a/src/Synapse/Time/TimeAwareInterface.php
+++ b/src/Synapse/Time/TimeAwareInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Synapse\Time;
+
+interface TimeAwareInterface
+{
+    public function setTimeObject(Time $time);
+}

--- a/src/Synapse/Time/TimeAwareTrait.php
+++ b/src/Synapse/Time/TimeAwareTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Synapse\Time;
+
+trait TimeAwareTrait
+{
+    protected $time;
+
+    public function setTimeObject(Time $time)
+    {
+        $this->time = $time;
+    }
+}

--- a/src/Synapse/Time/TimeServiceProvider.php
+++ b/src/Synapse/Time/TimeServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Synapse\Time;
+
+use Silex\ServiceProviderInterface;
+use Silex\Application;
+
+class TimeServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function register(Application $app)
+    {
+        $app->initializer(
+            'Synapse\Time\TimeAwareInterface',
+            function ($object, $app) {
+                $object->setTimeObject(new Time());
+                return $object;
+            }
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function boot(Application $app)
+    {
+        // Noop
+    }
+}


### PR DESCRIPTION
## Facilitate testing of time-related logic with TimeAwareInterface

Relying on the return values of the actual `time` and `date` functions in tests can result in non-deterministic tests, especially when testing edge cases. We should use our *AwareInterface pattern to inject a custom Time object in classes. The Time class will contain passthrough `date` and `time` methods.

### Acceptance Criteria
1. Not QA testable

### Tasks
- Add TimeAwareInterface with setTimeObject method
- Add TimeAwareTrait
- Add TimeMockInjector trait with injectMockTimeObject method.

### Additional Notes
- {{list additional notes here, remove if not applicable}}