### PR TITLE
RowExists constraint gives ContextErrorException when passing field in the options

### DIFF
--- a/src/Synapse/Validator/Constraints/RowExists.php
+++ b/src/Synapse/Validator/Constraints/RowExists.php
@@ -40,7 +40,7 @@ class RowExists extends Constraint
         }
 
         if (isset($options['field']) && (! isset($options['message']))) {
-            $this->message = $self::FIELD_MESSAGE;
+            $this->message = self::FIELD_MESSAGE;
         }
 
         if (! method_exists($mapper, 'findBy')) {

--- a/tests/Test/Synapse/Validator/Constraints/RowExistsTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowExistsTest.php
@@ -20,4 +20,11 @@ class RowExistsTest extends PHPUnit_Framework_TestCase
 
         $this->assertNotNull($constraint->getFilterCallback());
     }
+
+    public function testDefaultMessageIsSetIfFieldProvidedButNoMessageProvided()
+    {
+        $constraint = new RowExists($this->mockMapper, ['field' => 'foo']);
+
+        $this->assertEquals(RowExists::FIELD_MESSAGE, $constraint->message);
+    }
 }


### PR DESCRIPTION
## Description
RowExists constraint is giving an error message when passing in a `field`
```
ContextErrorException in RowExists.php line 43:
Notice: Undefined variable: self
```
Change `$self` to `self`
