### PR TITLE
RowNotExists constraint returns message from RowExists if no message is supplied

### DIFF
--- a/src/Synapse/Validator/Constraints/RowExists.php
+++ b/src/Synapse/Validator/Constraints/RowExists.php
@@ -40,7 +40,7 @@ class RowExists extends Constraint
         }
 
         if (isset($options['field']) && (! isset($options['message']))) {
-            $this->message = self::FIELD_MESSAGE;
+            $this->message = static::FIELD_MESSAGE;
         }
 
         if (! method_exists($mapper, 'findBy')) {

--- a/tests/Test/Synapse/Validator/Constraints/RowNotExistsTest.php
+++ b/tests/Test/Synapse/Validator/Constraints/RowNotExistsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Test\Synapse\Validator\Constraints;
+
+use PHPUnit_Framework_TestCase;
+use Synapse\Validator\Constraints\RowNotExists;
+
+class RowNotExistsTest extends PHPUnit_Framework_TestCase
+{
+    public function __construct()
+    {
+        $this->mockMapper = $this->getMockBuilder('Test\Synapse\Mapper\Mapper')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testDefaultMessageIsSetIfFieldProvidedButNoMessageProvided()
+    {
+        $constraint = new RowNotExists($this->mockMapper, ['field' => 'foo']);
+
+        $this->assertEquals(RowNotExists::FIELD_MESSAGE, $constraint->message);
+    }
+}


### PR DESCRIPTION
## Description
The RowNotExists constraint returns the FIELD_MESSAGE from RowExists if no custom message is supplied. 

Line 43 of RowExists.php is `$this->message = self::FIELD_MESSAGE;`
Should be changed to `$this->message = static::FIELD_MESSAGE;`