### PR TITLE
V2: Focus insertRow and updateRow methods

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -4,6 +4,54 @@ Upgrade Guide
 Pre-2.0.0 -> 2.0.0
 ------------------
 
+## Mapper changes
+
+### Update overridden `insert` and `update` methods
+
+Internally, `insert` and `update` call `insertRow` and `updateRow`, respectively, in order to perfom the actual database queries. Children who overrode `insert` or `update` previously may have called `insertRow` and `updateRow` internally. However, the logic that sets magic created/updated timestamp columns was moved from `insertRow` into `insert`. (Same for `updateRow` and `update`.)
+
+```PHP
+// Pre-2.0.0
+
+use Synapse\Mapper;
+use Synapse\Entity\AbstractEntity;
+
+class FooMapper extends Mapper\AbstractMapper {
+    use InserterTrait;
+
+    public function insert(AbstractEntity $entity)
+    {
+        $values = $entity->getArrayCopy();
+
+        // Custom logic to transform $values
+
+        return $this->insertRow($entity, $values);
+    }
+}
+```
+
+From 2.0.0 on, overridden `insert` and `update` methods should call the parent `insert` and `update` methods instead of `insertRow` and `updateRow`.
+
+```PHP
+// 2.0.0
+
+use Synapse\Mapper;
+use Synapse\Entity\AbstractEntity;
+
+class FooMapper extends Mapper\AbstractMapper {
+    use InserterTrait {
+        insert as parentInsert;
+    };
+
+    public function insert(AbstractEntity $entity)
+    {
+        // Custom logic to transform $entity
+
+        return $this->parentInsert($entity);
+    }
+}
+```
+
 ## Test changes
 
 A new TestCase class has been added, which includes a more concise way of

--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -85,7 +85,7 @@ trait FinderTrait
      * @param  array $options Array of options for this request.
      *                        May include 'order', 'page', or 'resultsPerPage'.
      * @return EntityIterator AbstractEntity objects
-     * @throws Exception      If pagination enabled and no 'order' option specified.
+     * @throws LogicException If pagination enabled and no 'order' option specified.
      */
     public function findAllBy(array $wheres, array $options = [])
     {

--- a/tests/Test/Synapse/Mapper/InserterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/InserterTraitTest.php
@@ -170,7 +170,7 @@ class InserterTraitTest extends MapperTestCase
 
     public function testInsertThrowsExceptionIfAutoincrementColumnNotInEntity()
     {
-        $this->setExpectedException('Synapse\Mapper\Exception');
+        $this->setExpectedException('LogicException');
 
         $entity = $this->createEntityToInsert();
 


### PR DESCRIPTION
## Focus insertRow and updateRow methods

In #107, methods in the `InserterTrait` and `UpdaterTrait` were extracted to encapsulate the database writing logic so that children could overwrite `insert` and `update` without rewriting that logic.

Since then, logic has been added to `insertRow` and `updateRow` to set timestamp columns. This logic belongs in `insert` and `update`, because it's uncorrelated with database interaction.

In order to separate concerns more clearly, all auto-setting of columns should be done in `insert` and `update`. `insertRow` and `updateRow` should only perform database interactions. (The only exception is that `insertRow` should set the auto-generated ID.)

### Acceptance Criteria
1. Auto timestamp setting in `InserterTrait` and `UpdaterTrait` is moved to `insert` and `update` methods.
1. `$values` are no longer passed to `insertRow` or `updateRow` -- only the `$entity`. (`$values` is just an implementation detail of those methods.)

### Tasks
- Make changes above

### Additional Notes
- Related to #181.