### PR TITLE
v2: Change user() to getUser() in SecurityAwareTrait

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -4,6 +4,12 @@ Upgrade Guide
 Pre-2.0.0 -> 2.0.0
 ------------------
 
+## Controller changes
+
+### Use `$this->getUser()` instead of `$this->user()` to get the logged in user
+
+The old method alias in `SecurityAwareTrait` has been removed.
+
 ## Mapper changes
 
 ### Update overridden `insert` and `update` methods

--- a/src/Synapse/Security/SecurityAwareInterface.php
+++ b/src/Synapse/Security/SecurityAwareInterface.php
@@ -16,5 +16,5 @@ interface SecurityAwareInterface
      *
      * @return mixed
      */
-    public function user();
+    public function getUser();
 }

--- a/src/Synapse/Security/SecurityAwareTrait.php
+++ b/src/Synapse/Security/SecurityAwareTrait.php
@@ -37,21 +37,12 @@ trait SecurityAwareTrait
             return null;
         }
 
-        if (!is_object($user = $token->getUser())) {
+        $user = $token->getUser();
+
+        if (! is_object($user)) {
             return null;
         }
 
         return $user;
-    }
-
-    /**
-     * Alias for the getUser() function
-     * To be deprecated in v2.0
-     *
-     * @return mixed
-     */
-    public function user()
-    {
-        return $this->getUser();
     }
 }

--- a/src/Synapse/User/UserController.php
+++ b/src/Synapse/User/UserController.php
@@ -41,7 +41,7 @@ class UserController extends AbstractRestController implements SecurityAwareInte
         $userEntity = $request->attributes->get('user');
 
         if ($userEntity === null) {
-            $userEntity = $this->user();
+            $userEntity = $this->getUser();
         } elseif ($userEntity === false) {
             return $this->createNotFoundResponse();
         }
@@ -90,7 +90,7 @@ class UserController extends AbstractRestController implements SecurityAwareInte
      */
     public function put(Request $request)
     {
-        $user = $this->user();
+        $user = $this->getUser();
 
         $userValidationCopy = clone $user;
 


### PR DESCRIPTION
## Change user() to getUser() in SecurityAwareTrait

Method names should be verbs, not nouns.