### PR TITLE
Patch 1.4.x to fix RowExists for older projects

### DIFF
--- a/src/Synapse/Validator/Constraints/RowExists.php
+++ b/src/Synapse/Validator/Constraints/RowExists.php
@@ -40,7 +40,7 @@ class RowExists extends Constraint
         }
 
         if (isset($options['field']) && (! isset($options['message']))) {
-            $this->message = $self::FIELD_MESSAGE;
+            $this->message = static::FIELD_MESSAGE;
         }
 
         if (! method_exists($mapper, 'findBy')) {


### PR DESCRIPTION
RowExists was fixed as part of 2.0.0, but older projects are on 1.x, so to maintain backwards compatibility we should fix this in 1.4 as well.