### PR TITLE
Create ArrayValidatorTestCase

### DIFF
--- a/src/Synapse/TestHelper/ArrayValidatorTestCase.php
+++ b/src/Synapse/TestHelper/ArrayValidatorTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Synapse\TestHelper;
+
+use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\DefaultTranslator;
+use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
+use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
+
+abstract class ArrayValidatorTestCase extends TestCase
+{
+    public function setUp()
+    {
+        $this->symfonyValidator = new Validator(
+            new ClassMetadataFactory(new StaticMethodLoader()),
+            new ConstraintValidatorFactory(),
+            new DefaultTranslator()
+        );
+    }
+}


### PR DESCRIPTION
## Create ArrayValidatorTestCase, so that array validators can easily be tested

### Acceptance Criteria
1. Test case simply sets up a Symfony `Validator` object.

### Tasks
- Create test case.

### Additional Notes
- It's most convenient if we use an instantiated Validator object rather than a mock. There's no point in mocking it; it would take a lot of needless work. We can go on the assumption that Symfony's Validator is functional.