### PR TITLE
Set role on user entity, not just database, in role service

### DIFF
--- a/src/Synapse/User/RoleService.php
+++ b/src/Synapse/User/RoleService.php
@@ -28,11 +28,11 @@ class RoleService
      */
     public function addRoleForUser(UserEntity $user, $role)
     {
-        $this->userRolePivotMapper->addRoleForUser($user->getId(), $role);
-
         $roles = $user->getRoles();
 
         if (! in_array($role, $roles)) {
+            $this->userRolePivotMapper->addRoleForUser($user->getId(), $role);
+
             array_push($roles, $role);
 
             $user->setRoles($roles);

--- a/src/Synapse/User/RoleService.php
+++ b/src/Synapse/User/RoleService.php
@@ -29,5 +29,13 @@ class RoleService
     public function addRoleForUser(UserEntity $user, $role)
     {
         $this->userRolePivotMapper->addRoleForUser($user->getId(), $role);
+
+        $roles = $user->getRoles();
+
+        if (! in_array($role, $roles)) {
+            array_push($roles, $role);
+
+            $user->setRoles($roles);
+        }
     }
 }

--- a/tests/Test/Synapse/User/RoleServiceTest.php
+++ b/tests/Test/Synapse/User/RoleServiceTest.php
@@ -56,4 +56,15 @@ class RoleServiceTest extends TestCase
 
         $this->assertContains(self::ROLE, $this->user->getRoles());
     }
+
+    public function testAddRoleForUserDoesNotPersistRoleToDatabaseOrAddToEntityIfAlreadyAdded()
+    {
+        $this->user->setRoles([self::ROLE]);
+        $this->assertCount(1, $this->user->getRoles());
+
+        $this->service->addRoleForUser($this->user, self::ROLE);
+
+        $this->assertCount(1, $this->user->getRoles());
+        $this->assertFalse(isset($this->captured->persistedRole));
+    }
 }

--- a/tests/Test/Synapse/User/RoleServiceTest.php
+++ b/tests/Test/Synapse/User/RoleServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Test\Synapse\User;
+
+use Synapse\TestHelper\TestCase;
+use Synapse\User\RoleService;
+use Synapse\User\UserEntity;
+use stdClass;
+
+class RoleServiceTest extends TestCase
+{
+    const ROLE    = 'ROLE_FOOD_BARN_BASS_QUACKS';
+    const USER_ID = 3;
+
+    public function setUp()
+    {
+        $this->captured = new stdClass;
+        $this->setMocks(['mapper' => 'Synapse\User\UserRolePivotMapper']);
+        $this->setUpMocks();
+
+        $this->service = new RoleService($this->mocks['mapper']);
+
+        $this->user = $this->getUser();
+    }
+
+    public function setUpMocks()
+    {
+        $this->mocks['mapper']->expects($this->any())
+            ->method('addRoleForUser')
+            ->will($this->returnCallback(function ($userId, $role) {
+                $this->captured->persistedRole = [
+                    'userId' => $userId,
+                    'role'   => $role,
+                ];
+            }));
+    }
+
+    public function getUser()
+    {
+        return new UserEntity(['id' => self::USER_ID]);
+    }
+
+    public function testAddRoleForUserPersistsRoleToDatabase()
+    {
+        $this->service->addRoleForUser($this->user, self::ROLE);
+
+        $this->assertEquals(self::ROLE, $this->captured->persistedRole['role']);
+        $this->assertSame($this->user->getId(), $this->captured->persistedRole['userId']);
+    }
+
+    public function testAddRoleForUserSetsRoleOnUserEntity()
+    {
+        $this->assertNotContains(self::ROLE, $this->user->getRoles());
+
+        $this->service->addRoleForUser($this->user, self::ROLE);
+
+        $this->assertContains(self::ROLE, $this->user->getRoles());
+    }
+}


### PR DESCRIPTION
## Set role on user entity, not just database, in role service

### Acceptance Criteria
1. Whenever `RoleService::addRoleForUser` is called, it actually sets the role on the user.

### Tasks
- Modify that class.

### Additional Notes
- None