### PR TITLE
Can create a user with an empty string for the email address

### DIFF
--- a/src/Synapse/User/UserRegistrationValidator.php
+++ b/src/Synapse/User/UserRegistrationValidator.php
@@ -14,9 +14,12 @@ class UserRegistrationValidator extends AbstractArrayValidator
     protected function getConstraints(array $contextData, AbstractEntity $contextEntity = null)
     {
         return [
-            'email' => new Assert\Email([
-                'checkHost' => true
-            ]),
+            'email' => [
+                new Assert\NotBlank(),
+                new Assert\Email([
+                    'checkHost' => true
+                ]),
+            ],
             'password' => new Assert\NotBlank(),
         ];
     }


### PR DESCRIPTION
## Description

It's possible to successfully submit the Create User endpoint with an empty string for the email address. The email constraint doesn't check whether the value is blank / empty string.

Add the NotBlank constraint.