### PR TITLE
install:generate assumes that DATADIR ends in a trailing slash

### DIFF
--- a/src/Synapse/Install/GenerateInstallCommand.php
+++ b/src/Synapse/Install/GenerateInstallCommand.php
@@ -159,7 +159,7 @@ class GenerateInstallCommand implements CommandInterface
             $this->dbConfig['database'],
             $this->dbConfig['username'],
             $this->dbConfig['password'],
-            $outputPath.self::STRUCTURE_FILE
+            $outputPath.'/'.self::STRUCTURE_FILE
         ));
     }
 
@@ -186,7 +186,7 @@ class GenerateInstallCommand implements CommandInterface
             implode(' ', $tables),
             escapeshellarg($this->dbConfig['username']),
             escapeshellarg($this->dbConfig['password']),
-            escapeshellarg($outputPath.self::DATA_FILE)
+            escapeshellarg($outputPath.'/'.self::DATA_FILE)
         );
 
         return shell_exec($command);


### PR DESCRIPTION
## install:generate assumes that DATADIR ends in a trailing slash

It seems that our convention is to not end paths defined in `console` and `index.php` with trailing slashes, yet that assumption is made [here](https://github.com/synapsestudios/synapse-base/blob/master/src/Synapse/Install/GenerateInstallCommand.php#L162) and [here](https://github.com/synapsestudios/synapse-base/blob/master/src/Synapse/Install/GenerateInstallCommand.php#L189). As a result, the generated DB files will be placed at the root directory with the prefix `data` instead of in the `data` directory.

