### PR TITLE
Return more "constant-ey" validation message when fields are missing in AbstractArrayValidator

### DIFF
--- a/src/Synapse/Validator/AbstractArrayValidator.php
+++ b/src/Synapse/Validator/AbstractArrayValidator.php
@@ -50,7 +50,10 @@ abstract class AbstractArrayValidator
 
         $constraints = $this->getConstraints($values, $contextEntity);
 
-        $arrayConstraint = new Assert\Collection($constraints);
+        $arrayConstraint = new Assert\Collection([
+            'fields'               => $constraints,
+            'missingFieldsMessage' => 'MISSING',
+        ]);
 
         return $this->validator->validateValue(
             $values,

--- a/src/Synapse/Validator/AbstractArrayValidator.php
+++ b/src/Synapse/Validator/AbstractArrayValidator.php
@@ -14,6 +14,8 @@ use Synapse\Entity\AbstractEntity;
  */
 abstract class AbstractArrayValidator
 {
+    const MISSING = 'MISSING';
+
     /**
      * Symfony validator component
      *
@@ -52,7 +54,7 @@ abstract class AbstractArrayValidator
 
         $arrayConstraint = new Assert\Collection([
             'fields'               => $constraints,
-            'missingFieldsMessage' => 'MISSING',
+            'missingFieldsMessage' => self::MISSING,
         ]);
 
         return $this->validator->validateValue(

--- a/tests/Test/Synapse/Validator/AbstractArrayValidatorTest.php
+++ b/tests/Test/Synapse/Validator/AbstractArrayValidatorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Test\Synapse\Validator;
+
+use Synapse\TestHelper\ArrayValidatorTestCase;
+use Synapse\Validator\AbstractArrayValidator;
+
+class AbstractArrayValidatorTest extends ArrayValidatorTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->validator = new ArrayValidator($this->symfonyValidator);
+    }
+
+    public function testMissingFieldsReturnCorrectMessage()
+    {
+        $errors = $this->validator->validate([]);
+
+        $this->assertEquals(AbstractArrayValidator::MISSING, $errors->get(0)->getMessage());
+    }
+}

--- a/tests/Test/Synapse/Validator/ArrayValidator.php
+++ b/tests/Test/Synapse/Validator/ArrayValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Test\Synapse\Validator;
+
+use Synapse\Validator\AbstractArrayValidator;
+use Synapse\Entity\AbstractEntity;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class ArrayValidator extends AbstractArrayValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConstraints(array $contextData, AbstractEntity $contextEntity = null)
+    {
+        return [
+            'foo' => new NotBlank()
+        ];
+    }
+}


### PR DESCRIPTION
## Return more "constant-ey" validation message when fields are missing in AbstractArrayValidator

### Acceptance Criteria
1. When fields are missing from validators that extend the AbstractArrayValidator, return `MISSING` as the error message rather than the default, `This field is missing.`.

### Tasks
- Add `missingFieldsMessage` to `Collection` constraint options.

### Additional Notes
- Since we're doing i18n on the front-ends, we're moving to this approach for validation errors.