### PR TITLE
Configuration setting for disabling login before email verification

### DIFF
--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -82,7 +82,7 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
     protected $session;
 
     /**
-     * @var bool
+     * @var boolean
      */
     protected $requireVerification;
 
@@ -93,7 +93,7 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
      * @param RefreshTokenMapper $refreshTokenMapper
      * @param Mustache_Engine    $mustache
      * @param Session            $session
-     * @param array              $loginConfiguration
+     * @param boolean            $requireVerification
      */
     public function __construct(
         OAuth2Server $server,
@@ -102,20 +102,15 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
         RefreshTokenMapper $refreshTokenMapper,
         Mustache_Engine $mustache,
         Session $session,
-        array $loginConfiguration
+        $requireVerification
     ) {
-        $this->server             = $server;
-        $this->userService        = $userService;
-        $this->accessTokenMapper  = $accessTokenMapper;
-        $this->refreshTokenMapper = $refreshTokenMapper;
-        $this->mustache           = $mustache;
-        $this->session            = $session;
-
-        if (Arr::get($loginConfiguration, 'requireVerification', false)) {
-            $this->requireVerification = true;
-        } else {
-            $this->requireVerification = false;
-        }
+        $this->server              = $server;
+        $this->userService         = $userService;
+        $this->accessTokenMapper   = $accessTokenMapper;
+        $this->refreshTokenMapper  = $refreshTokenMapper;
+        $this->mustache            = $mustache;
+        $this->session             = $session;
+        $this->requireVerification = $requireVerification;
     }
 
     /**

--- a/src/Synapse/OAuth2/ServerServiceProvider.php
+++ b/src/Synapse/OAuth2/ServerServiceProvider.php
@@ -63,7 +63,7 @@ class ServerServiceProvider implements ServiceProviderInterface
         $app['oauth.controller'] = $app->share(function ($app) {
             try {
                 $loginConfiguration = $app['config']->load('login');
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 $loginConfiguration = [];
             }
 

--- a/src/Synapse/OAuth2/ServerServiceProvider.php
+++ b/src/Synapse/OAuth2/ServerServiceProvider.php
@@ -61,11 +61,7 @@ class ServerServiceProvider implements ServiceProviderInterface
         });
 
         $app['oauth.controller'] = $app->share(function ($app) {
-            try {
-                $loginConfiguration = $app['config']->load('login');
-            } catch (Exception $e) {
-                $loginConfiguration = [];
-            }
+            $loginConfiguration = $app['config']->load('login');
 
             return new OAuthController(
                 $app['oauth_server'],
@@ -74,7 +70,7 @@ class ServerServiceProvider implements ServiceProviderInterface
                 $app['oauth-refresh-token.mapper'],
                 $app['mustache'],
                 $app['session'],
-                $loginConfiguration
+                $loginConfiguration['requireVerification']
             );
         });
 

--- a/src/Synapse/OAuth2/ServerServiceProvider.php
+++ b/src/Synapse/OAuth2/ServerServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Synapse\OAuth2;
 
+use Exception;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\HttpFoundation\RequestMatcher;
@@ -60,13 +61,20 @@ class ServerServiceProvider implements ServiceProviderInterface
         });
 
         $app['oauth.controller'] = $app->share(function ($app) {
+            try {
+                $loginConfiguration = $app['config']->load('login');
+            } catch(Exception $e) {
+                $loginConfiguration = [];
+            }
+
             return new OAuthController(
                 $app['oauth_server'],
                 $app['user.service'],
                 $app['oauth-access-token.mapper'],
                 $app['oauth-refresh-token.mapper'],
                 $app['mustache'],
-                $app['session']
+                $app['session'],
+                $loginConfiguration
             );
         });
 

--- a/tests/Test/Synapse/OAuth2/OAuthControllerTest.php
+++ b/tests/Test/Synapse/OAuth2/OAuthControllerTest.php
@@ -22,7 +22,6 @@ class OAuthControllerTest extends ControllerTestCase
         $this->setUpMockMustacheEngine();
         $this->setUpMockSession();
         $this->setUpMockUrlGenerator();
-        $this->setUpMockLoginConfig();
 
         $this->controller = new OAuthController(
             $this->mockOAuth2Server,
@@ -31,7 +30,7 @@ class OAuthControllerTest extends ControllerTestCase
             $this->mockRefreshTokenMapper,
             $this->mockMustacheEngine,
             $this->mockSession,
-            $this->mockLoginConfig
+            true
         );
 
         $this->controller->setUrlGenerator($this->mockUrlGenerator);
@@ -84,13 +83,6 @@ class OAuthControllerTest extends ControllerTestCase
         $this->mockUrlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')
             ->disableOriginalConstructor()
             ->getMock();
-    }
-
-    public function setUpMockLoginConfig()
-    {
-        $this->mockLoginConfig = [
-            'requireVerification' => true,
-        ];
     }
 
     public function expectingTemplateVarsSet($vars)


### PR DESCRIPTION
### Acceptance Criteria
1. An app configuration setting exists to disable login without verifying your account
1. When this flag is set, unverified accounts cannot log in
1. If the "enabled" flag in the database is not set, account cannot log in

### Tasks
- Add config setting
- Update `Synapse\OAuth2\ServerServiceProvider` to pass the configuration setting into the OAuthController
- Update `Synapse\OAuth2\OAuthController` to check if the config setting is true and if so, check if the "verified" flag is set on the user entity before allowing login
- Update `Synapse\OAuth2\OAuthController` to check if the user's enabled flag is set before allowing login
- Update tests where necessary