### PR TITLE
Pass CliCommandOptions to AbstractCliCommand::getBaseCommand()

### DIFF
--- a/src/Synapse/CliCommand/AbstractCliCommand.php
+++ b/src/Synapse/CliCommand/AbstractCliCommand.php
@@ -15,7 +15,7 @@ abstract class AbstractCliCommand
      *
      * @return string shell command plus parameters
      */
-    abstract protected function getBaseCommand();
+    abstract protected function getBaseCommand(CliCommandOptions $options);
 
     protected function buildCommand(CliCommandOptions $options)
     {

--- a/src/Synapse/CliCommand/AbstractCliCommand.php
+++ b/src/Synapse/CliCommand/AbstractCliCommand.php
@@ -21,7 +21,7 @@ abstract class AbstractCliCommand
     {
         return trim(sprintf(
             '%s %s',
-            $this->getBaseCommand(),
+            $this->getBaseCommand($options),
             $options->getRedirect()
         ));
     }

--- a/tests/Test/Synapse/CliCommand/CliCommand.php
+++ b/tests/Test/Synapse/CliCommand/CliCommand.php
@@ -3,6 +3,7 @@
 namespace Test\Synapse\CliCommand;
 
 use Synapse\CliCommand\AbstractCliCommand;
+use Synapse\CliCommand\CliCommandOptions;
 
 class CliCommand extends AbstractCliCommand
 {
@@ -11,7 +12,7 @@ class CliCommand extends AbstractCliCommand
     /**
      * {@inheritdoc }
      */
-    protected function getBaseCommand()
+    protected function getBaseCommand(CliCommandOptions $options)
     {
         return escapeshellcmd($this->command);
     }


### PR DESCRIPTION
## The CliCommandOptions can be used to build the base command for CliCommands

### Acceptance Criteria
1. Pass `CliCommandOptions $options` as parameter to `AbstractCliCommand::getBaseCommand()` definition
