### PR TITLE
Email Whitelist / Trapping Broken

### DIFF
--- a/src/Synapse/Email/AbstractSender.php
+++ b/src/Synapse/Email/AbstractSender.php
@@ -3,6 +3,7 @@
 namespace Synapse\Email;
 
 use Synapse\Stdlib\Arr;
+use RuntimeException;
 
 abstract class AbstractSender implements SenderInterface
 {
@@ -68,6 +69,10 @@ abstract class AbstractSender implements SenderInterface
     protected function injectIntoTrapAddress($address)
     {
         $trapAddress = Arr::path($this->config, 'whitelist.trap');
+
+        if (! $trapAddress) {
+            throw new RuntimeException('Email address not whitelisted but no email trap exists');
+        }
 
         $address = str_ireplace('@', '+', $address);
 

--- a/tests/Test/Synapse/Email/AbstractSenderTest.php
+++ b/tests/Test/Synapse/Email/AbstractSenderTest.php
@@ -23,6 +23,21 @@ class AbstractSenderTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * A test configuration with no valid emails but no trap set
+     *
+     * @return array
+     */
+    public function getMalconfiguredTestConfig()
+    {
+        return [
+            'whitelist' => [
+                'list' => [],
+                'trap' => null,
+            ],
+        ];
+    }
+
     public function provideWhitelistedAddresses()
     {
         return [
@@ -63,5 +78,14 @@ class AbstractSenderTest extends PHPUnit_Framework_TestCase
             $expectedFilteredAddress,
             $this->sender->getFilteredEmailAddress($emailAddress)
         );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testFilterThroughWhitelistThrowsExceptionTryingToSendToTrapAddressButNoneSet()
+    {
+        $this->sender->setConfig($this->getMalconfiguredTestConfig());
+        $this->sender->getFilteredEmailAddress('foo@bar.com');
     }
 }


### PR DESCRIPTION
## Description

Ran into this issue on a production install.

If the email whitelist is empty, all emails will be sent to the trap, but if the trap is `null` (which it is by default) then `AbstractSender::injectIntoTrapAddress` will result in this error:

```
PHP Notice:  Undefined offset: 1 in /srv/www/api/releases/20150511181249/vendor/synapsestudios/synapse-base/src/Synapse/Email/AbstractSender.php on line 74
```

Here's the offending code:

```PHP
list($trapName, $trapDomain) = explode('@', $trapAddress);
```

## Details

- Expected behavior: If the trap isn't an email address, then an exception is thrown saying, "You need a trap email address".