### PR TITLE
Return JSON responses only

### DIFF
--- a/src/Synapse/User/ResetPasswordController.php
+++ b/src/Synapse/User/ResetPasswordController.php
@@ -87,7 +87,7 @@ class ResetPasswordController extends AbstractRestController
 
         $this->emailService->enqueueSendEmailJob($email);
 
-        return $this->createSimpleResponse(204, '');
+        return $this->create204Response(204, '');
     }
 
     /**
@@ -124,7 +124,7 @@ class ResetPasswordController extends AbstractRestController
 
         // Ensure user input is valid
         if (! $password) {
-            return $this->createSimpleResponse(422, 'Password cannot be empty');
+            return $this->createErrorResponse(['password' => ['EMPTY']], 422);
         }
 
         $this->userService->resetPassword($user, $password);

--- a/src/Synapse/User/UserService.php
+++ b/src/Synapse/User/UserService.php
@@ -17,11 +17,10 @@ class UserService
     /**
      * Error codes to return for specific exceptions
      */
-    const CURRENT_PASSWORD_REQUIRED = 1;
-    const EMAIL_NOT_UNIQUE          = 2;
-    const INCORRECT_TOKEN_TYPE      = 3;
-    const TOKEN_EXPIRED             = 4;
-    const TOKEN_NOT_FOUND           = 5;
+    const EMAIL_NOT_UNIQUE     = 1;
+    const INCORRECT_TOKEN_TYPE = 2;
+    const TOKEN_EXPIRED        = 3;
+    const TOKEN_NOT_FOUND      = 4;
 
     /**
      * @var UserMapper

--- a/src/Synapse/User/UserService.php
+++ b/src/Synapse/User/UserService.php
@@ -6,6 +6,8 @@ use Synapse\Email\EmailService;
 use Synapse\View\Email\VerifyRegistration as VerifyRegistrationView;
 use Synapse\Stdlib\Arr;
 use OutOfBoundsException;
+use LogicException;
+use Synapse\Validator\AbstractArrayValidator;
 
 /**
  * Service for general purpose tasks regarding the user
@@ -16,11 +18,10 @@ class UserService
      * Error codes to return for specific exceptions
      */
     const CURRENT_PASSWORD_REQUIRED = 1;
-    const FIELD_CANNOT_BE_EMPTY     = 2;
-    const EMAIL_NOT_UNIQUE          = 3;
-    const INCORRECT_TOKEN_TYPE      = 4;
-    const TOKEN_EXPIRED             = 5;
-    const TOKEN_NOT_FOUND           = 6;
+    const EMAIL_NOT_UNIQUE          = 2;
+    const INCORRECT_TOKEN_TYPE      = 3;
+    const TOKEN_EXPIRED             = 4;
+    const TOKEN_NOT_FOUND           = 5;
 
     /**
      * @var UserMapper
@@ -83,10 +84,7 @@ class UserService
             $currentPassword = Arr::get($data, 'current_password');
 
             if (! $currentPassword or ! password_verify($currentPassword, $user->getPassword())) {
-                throw new OutOfBoundsException(
-                    'Current password missing or incorrect',
-                    self::CURRENT_PASSWORD_REQUIRED
-                );
+                throw new LogicException('Trying to update email or password but current password incorrect');
             }
         }
 
@@ -96,19 +94,12 @@ class UserService
 
         // Update email
         if (isset($data['email'])) {
-            if (! $data['email']) {
-                throw new OutOfBoundsException(
-                    'Email cannot be empty',
-                    self::FIELD_CANNOT_BE_EMPTY
-                );
-            }
-
             if ($data['email'] !== $user->getEmail()) {
                 $alreadyCreatedUser = $this->userMapper->findByEmail($data['email']);
 
                 if ($alreadyCreatedUser) {
                     throw new OutOfBoundsException(
-                        'A user was already created with this email address.',
+                        'EMAIL_NOT_UNIQUE',
                         self::EMAIL_NOT_UNIQUE
                     );
                 }
@@ -119,13 +110,6 @@ class UserService
 
         // Update password
         if (isset($data['password'])) {
-            if (! $data['password']) {
-                throw new OutOfBoundsException(
-                    'Password cannot be empty',
-                    self::FIELD_CANNOT_BE_EMPTY
-                );
-            }
-
             $update['password'] = $this->hashPassword($data['password']);
         }
 
@@ -263,18 +247,15 @@ class UserService
     public function verifyRegistration(TokenEntity $token)
     {
         if ($token->isNew()) {
-            throw new OutOfBoundsException('Token not found.', self::TOKEN_NOT_FOUND);
+            throw new OutOfBoundsException('NOT_FOUND', self::TOKEN_NOT_FOUND);
         }
 
         if ((int) $token->getTokenTypeId() !== TokenEntity::TYPE_VERIFY_REGISTRATION) {
-            $format  = 'Token specified is of type %s. Expected %s.';
-            $message = sprintf($format, $token->getTokenTypeId(), TokenEntity::TYPE_VERIFY_REGISTRATION);
-
-            throw new OutOfBoundsException($message, self::INCORRECT_TOKEN_TYPE);
+            throw new OutOfBoundsException('NOT_FOUND', self::INCORRECT_TOKEN_TYPE);
         }
 
         if ($token->getExpires() < time()) {
-            throw new OutOfBoundsException('Token expired', self::TOKEN_EXPIRED);
+            throw new OutOfBoundsException('EXPIRED', self::TOKEN_EXPIRED);
         }
 
         $user = $this->findById($token->getUserId());

--- a/src/Synapse/User/UserValidator.php
+++ b/src/Synapse/User/UserValidator.php
@@ -13,6 +13,8 @@ class UserValidator extends AbstractArrayValidator implements SecurityAwareInter
 {
     use SecurityAwareTrait;
 
+    const BLANK = 'BLANK';
+
     /**
      * $contextEntity is the currently logged in user's UserEntity
      *
@@ -20,21 +22,21 @@ class UserValidator extends AbstractArrayValidator implements SecurityAwareInter
      */
     protected function getConstraints(array $contextData, AbstractEntity $contextEntity = null)
     {
+        $notBlank = new Assert\NotBlank(['message' => self::BLANK]);
+
         $constraints = [
             'email' => new Assert\Optional([
-                new Assert\NotBlank(),
+                $notBlank,
                 new Assert\Email([
                     'checkHost' => true
                 ]),
             ]),
-            'password' => new Assert\Optional([
-                new Assert\NotBlank(),
-            ])
+            'password' => new Assert\Optional([$notBlank])
         ];
 
         if (isset($contextData['email']) or isset($contextData['password'])) {
             $constraints['current_password'] = [
-                new Assert\NotBlank(),
+                $notBlank,
                 new Assert\Callback(['callback' => [$this, 'validateCurrentPassword']]),
             ];
         }

--- a/src/Synapse/User/UserValidator.php
+++ b/src/Synapse/User/UserValidator.php
@@ -3,18 +3,22 @@
 namespace Synapse\User;
 
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ExecutionContextInterface as ExecutionContext;
 use Synapse\Entity\AbstractEntity;
 use Synapse\Validator\AbstractArrayValidator;
 
 class UserValidator extends AbstractArrayValidator
 {
     /**
+     * $contextEntity is the currently logged in user's UserEntity
+     *
      * {@inheritDoc}
      */
     protected function getConstraints(array $contextData, AbstractEntity $contextEntity = null)
     {
         $constraints = [
             'email' => new Assert\Optional([
+                new Assert\NotBlank(),
                 new Assert\Email([
                     'checkHost' => true
                 ]),
@@ -25,9 +29,27 @@ class UserValidator extends AbstractArrayValidator
         ];
 
         if (isset($contextData['email']) or isset($contextData['password'])) {
-            $constraints['current_password'] = new Assert\NotBlank();
+            $constraints['current_password'] = [
+                new Assert\NotBlank(),
+                new Assert\Callback([$this, 'validateCurrentPassword']),
+            ];
         }
 
         return $constraints;
+    }
+
+    /**
+     * Validate whether the current password is correct (meant to be used in a Callback constraint)
+     *
+     * Adds violation to $context if it's wrong
+     *
+     * @param  string           $password The current password
+     * @param  ExecutionContext $context
+     */
+    protected function validateCurrentPassword($password, ExecutionContext $context)
+    {
+        if (! password_verify($password, $contextEntity->getPassword())) {
+            $context->addViolation('INVALID');
+        }
     }
 }

--- a/src/Synapse/User/VerifyRegistrationController.php
+++ b/src/Synapse/User/VerifyRegistrationController.php
@@ -58,7 +58,10 @@ class VerifyRegistrationController extends AbstractRestController implements Sec
                 UserService::TOKEN_NOT_FOUND      => 404,
             ];
 
-            return $this->createSimpleResponse($httpCodes[$e->getCode()], $e->getMessage());
+            return $this->createErrorResponse(
+                ['token' => ['INVALID']],
+                $httpCodes[$e->getCode()]
+            );
         }
 
         $user = $user->getArrayCopy();

--- a/tests/Test/Synapse/User/UserControllerTest.php
+++ b/tests/Test/Synapse/User/UserControllerTest.php
@@ -323,28 +323,6 @@ class UserControllerTest extends ControllerTestCase
         );
     }
 
-    public function testPutReturns403IfOutOfBoundsExceptionThrownWithPasswordRequiredErrorCode()
-    {
-        $this->withUserUpdateThrowingExceptionWithCode(
-            UserService::CURRENT_PASSWORD_REQUIRED
-        );
-
-        $response = $this->makePutRequest();
-
-        $this->assertEquals(403, $response->getStatusCode());
-    }
-
-    public function testPutReturns422IfOutOfBoundsExceptionThrownWithEmptyFieldErrorCode()
-    {
-        $this->withUserUpdateThrowingExceptionWithCode(
-            UserService::FIELD_CANNOT_BE_EMPTY
-        );
-
-        $response = $this->makePutRequest();
-
-        $this->assertEquals(422, $response->getStatusCode());
-    }
-
     public function testPutReturns422IfValidationConstraintsAreViolated()
     {
         $this->withValidatorValidateReturningErrors();

--- a/tests/Test/Synapse/User/UserServiceTest.php
+++ b/tests/Test/Synapse/User/UserServiceTest.php
@@ -179,7 +179,7 @@ class UserServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException OutOfBoundsException
+     * @expectedException LogicException
      */
     public function testExceptionThrownIfAttemptingToSetEmailWithoutSpecifyingCurrentPassword()
     {
@@ -190,41 +190,13 @@ class UserServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException OutOfBoundsException
+     * @expectedException LogicException
      */
     public function testExceptionThrownIfAttemptingToSetPasswordWithoutSpecifyingCurrentPassword()
     {
         $this->userService->update(
             $this->getUserEntity(),
             ['password' => 'new_password']
-        );
-    }
-
-    /**
-     * @expectedException OutOfBoundsException
-     */
-    public function testExceptionThrownIfAttemptingToSetEmptyEmail()
-    {
-        $this->userService->update(
-            $this->getUserEntity(),
-            [
-                'current_password' => self::CURRENT_PASSWORD,
-                'email'            => ''
-            ]
-        );
-    }
-
-    /**
-     * @expectedException OutOfBoundsException
-     */
-    public function testExceptionThrownIfAttemptingToSetEmptyPassword()
-    {
-        $this->userService->update(
-            $this->getUserEntity(),
-            [
-                'current_password' => self::CURRENT_PASSWORD,
-                'password'         => ''
-            ]
         );
     }
 


### PR DESCRIPTION
## Return JSON responses only

Many of our endpoints are set up to return plaintext responses, but this is not as simply readable by the front end app as JSON.

### Acceptance Criteria
1. The Reset Password endpoint (`PUT /user/reset-password`) returns JSON error instead of plaintext when the password is empty.
1. The Create User endpoint (`POST /users`) returns JSON error instead of plaintext when the email address is not unique.
1. The Create User endpoint (`POST /users`) returns JSON error instead of plaintext when the email address is not unique.
1. The Edit User endpoint (`POST /users`) returns JSON error instead of plaintext when (1) the current password is wrong/not provided, (2) the email or new password is empty, and (3) the email address is not unique.
1. The Verify Registration endpoint (`POST /users/{id}/verify-registration`) returns JSON error instead of plaintext when (1) the token is not specified, (2) the token is of an incorrect type, (3) the token has expired, and (4) the token has not been found.
1. All validation errors that have to do with a specific field are returned as a Validation error shape instead of just an error shape:

(Like this:)

```JSON
{
    "errors" : {
        "some_field" : ["INVALID", "OTHER_PROBLEM"]
    }
}
```

### Tasks
- Change `createSimpleResponse` to `createErrorResponse` in many cases.
- Make validators where necessary.

### Additional Notes
- It turned out some of the responses were already being handled by validators, and we had unnecessary checks and exception handling in our controllers/services.
