### PR TITLE
Make validation errors constant-y

### DIFF
--- a/src/Synapse/Validator/AbstractArrayValidator.php
+++ b/src/Synapse/Validator/AbstractArrayValidator.php
@@ -14,7 +14,8 @@ use Synapse\Entity\AbstractEntity;
  */
 abstract class AbstractArrayValidator
 {
-    const MISSING = 'MISSING';
+    const MISSING       = 'MISSING';
+    const NOT_EXPECTING = 'NOT_EXPECTING';
 
     /**
      * Symfony validator component
@@ -55,6 +56,7 @@ abstract class AbstractArrayValidator
         $arrayConstraint = new Assert\Collection([
             'fields'               => $constraints,
             'missingFieldsMessage' => self::MISSING,
+            'extraFieldsMessage'   => self::NOT_EXPECTING
         ]);
 
         return $this->validator->validateValue(

--- a/src/Synapse/Validator/Constraints/I18n/BelongsToEntity.php
+++ b/src/Synapse/Validator/Constraints/I18n/BelongsToEntity.php
@@ -10,6 +10,6 @@ class BelongsToEntity extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Synapse\Validator\Constraints\BelongsToEntityValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/BelongsToEntity.php
+++ b/src/Synapse/Validator/Constraints/I18n/BelongsToEntity.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Synapse\Validator\Constraints\BelongsToEntity as ParentConstraint;
+
+class BelongsToEntity extends ParentConstraint
+{
+    public $message = 'DOES_NOT_BELONG_TO_ENTITY';
+
+    public function validatedBy()
+    {
+        return 'Synapse\Validator\COnstraints\BelongsToEntityValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/BelongsToEntity.php
+++ b/src/Synapse/Validator/Constraints/I18n/BelongsToEntity.php
@@ -10,6 +10,6 @@ class BelongsToEntity extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Synapse\Validator\COnstraints\BelongsToEntityValidator';
+        return 'Synapse\Validator\Constraints\BelongsToEntityValidator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Blank.php
+++ b/src/Synapse/Validator/Constraints/I18n/Blank.php
@@ -10,6 +10,6 @@ class Blank extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\BlankValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Blank.php
+++ b/src/Synapse/Validator/Constraints/I18n/Blank.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Blank as ParentConstraint;
+
+class Blank extends ParentConstraint
+{
+    public $message = 'NOT_BLANK';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\BlankValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/CardScheme.php
+++ b/src/Synapse/Validator/Constraints/I18n/CardScheme.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\CardScheme as ParentConstraint;
+
+class CardScheme extends ParentConstraint
+{
+    public $message = 'UNSUPPORTED_CARD_TYPE_OR_INVALID_CARD_NUMBER';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\CardSchemeValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/CardScheme.php
+++ b/src/Synapse/Validator/Constraints/I18n/CardScheme.php
@@ -10,6 +10,6 @@ class CardScheme extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\CardSchemeValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Choice.php
+++ b/src/Synapse/Validator/Constraints/I18n/Choice.php
@@ -13,6 +13,6 @@ class Choice extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\ChoiceValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Choice.php
+++ b/src/Synapse/Validator/Constraints/I18n/Choice.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Choice as ParentConstraint;
+
+class Choice extends ParentConstraint
+{
+    public $message         = 'NOT_A_VALID_CHOICE';
+    public $multipleMessage = 'ONE_OR_MORE_INVALID_VALUES';
+    public $minMessage      = 'LESS_THAN_MIN_CHOICES_SELECTED';
+    public $maxMessage      = 'MORE_THAN_MAX_CHOICES_SELECTED';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\ChoiceValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Count.php
+++ b/src/Synapse/Validator/Constraints/I18n/Count.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Count as ParentConstraint;
+
+class Count extends ParentConstraint
+{
+    public $minMessage   = 'COUNT_LESS_THAN_MIN';
+    public $maxMessage   = 'COUNT_MORE_THAN_MAX';
+    public $exactMessage = 'COUNT_NOT_EXACT';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\CountValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Count.php
+++ b/src/Synapse/Validator/Constraints/I18n/Count.php
@@ -12,6 +12,6 @@ class Count extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\CountValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Country.php
+++ b/src/Synapse/Validator/Constraints/I18n/Country.php
@@ -10,6 +10,6 @@ class Country extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\CountryValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Country.php
+++ b/src/Synapse/Validator/Constraints/I18n/Country.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Country as ParentConstraint;
+
+class Country extends ParentConstraint
+{
+    public $message = 'INVALID_COUNTRY';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\CountryValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Currency.php
+++ b/src/Synapse/Validator/Constraints/I18n/Currency.php
@@ -10,6 +10,6 @@ class Currency extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\CurrencyValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Currency.php
+++ b/src/Synapse/Validator/Constraints/I18n/Currency.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Currency as ParentConstraint;
+
+class Currency extends ParentConstraint
+{
+    public $message = 'INVALID_CURRENCY';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\CurrencyValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Date.php
+++ b/src/Synapse/Validator/Constraints/I18n/Date.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Date as ParentConstraint;
+
+class Date extends ParentConstraint
+{
+    public $message = 'INVALID_DATE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\DateValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Date.php
+++ b/src/Synapse/Validator/Constraints/I18n/Date.php
@@ -10,6 +10,6 @@ class Date extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\DateValidator';
+        return parent::class . 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/DateTime.php
+++ b/src/Synapse/Validator/Constraints/I18n/DateTime.php
@@ -10,6 +10,6 @@ class DateTime extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\DateTimeValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/DateTime.php
+++ b/src/Synapse/Validator/Constraints/I18n/DateTime.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\DateTime as ParentConstraint;
+
+class DateTime extends ParentConstraint
+{
+    public $message = 'INVALID_DATETIME';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\DateTimeValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Email.php
+++ b/src/Synapse/Validator/Constraints/I18n/Email.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Email as ParentConstraint;
+
+class Email extends ParentConstraint
+{
+    public $message = 'INVALID_EMAIL';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\EmailValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Email.php
+++ b/src/Synapse/Validator/Constraints/I18n/Email.php
@@ -10,6 +10,6 @@ class Email extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\EmailValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/EqualTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/EqualTo.php
@@ -10,6 +10,6 @@ class EqualTo extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\EqualToValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/EqualTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/EqualTo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\EqualTo as ParentConstraint;
+
+class EqualTo extends ParentConstraint
+{
+    public $message = 'MUST_BE_EQUAL_TO';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\EqualToValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Expression.php
+++ b/src/Synapse/Validator/Constraints/I18n/Expression.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Expression as ParentConstraint;
+
+class Expression extends ParentConstraint
+{
+    public $message = 'INVALID';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\ExpressionValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Expression.php
+++ b/src/Synapse/Validator/Constraints/I18n/Expression.php
@@ -10,6 +10,6 @@ class Expression extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\ExpressionValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/False.php
+++ b/src/Synapse/Validator/Constraints/I18n/False.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\False as ParentConstraint;
+
+class False extends ParentConstraint
+{
+    public $message = 'MUST_BE_FALSE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\FalseValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/False.php
+++ b/src/Synapse/Validator/Constraints/I18n/False.php
@@ -10,6 +10,6 @@ class False extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\FalseValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/File.php
+++ b/src/Synapse/Validator/Constraints/I18n/File.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\File as ParentConstraint;
+
+class File extends ParentConstraint
+{
+    public $notFoundMessage    = 'FILE_NOT_FOUND';
+    public $notReadableMessage = 'FILE_NOT_READABLE';
+    public $maxSizeMessage     = 'FILE_TOO_BIG';
+    public $mimeTypesMessage   = 'TYPE_NOT_ALLOWED';
+
+    public $uploadIniSizeErrorMessage   = 'FILE_TOO_BIG';
+    public $uploadFormSizeErrorMessage  = 'FILE_TOO_BIG';
+    public $uploadPartialErrorMessage   = 'INCOMPLETE_UPLOAD';
+    public $uploadNoFileErrorMessage    = 'NO_FILE_UPLOADED';
+    public $uploadNoTmpDirErrorMessage  = 'NO_TEMP_FOLDER_CONFIGURED';
+    public $uploadCantWriteErrorMessage = 'CANNOT_WRITE_TO_DISK';
+    public $uploadExtensionErrorMessage = 'PHP_EXTENSION_ERROR';
+    public $uploadErrorMessage          = 'UPLOAD_ERROR';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\FileValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/File.php
+++ b/src/Synapse/Validator/Constraints/I18n/File.php
@@ -22,6 +22,6 @@ class File extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\FileValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/GreaterThan.php
+++ b/src/Synapse/Validator/Constraints/I18n/GreaterThan.php
@@ -10,6 +10,6 @@ class GreaterThan extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\GreaterThanValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/GreaterThan.php
+++ b/src/Synapse/Validator/Constraints/I18n/GreaterThan.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\GreaterThan as ParentConstraint;
+
+class GreaterThan extends ParentConstraint
+{
+    public $message = 'MUST_BE_GREATER_THAN';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\GreaterThanValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/GreaterThanOrEqual.php
+++ b/src/Synapse/Validator/Constraints/I18n/GreaterThanOrEqual.php
@@ -10,6 +10,6 @@ class GreaterThanOrEqual extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/GreaterThanOrEqual.php
+++ b/src/Synapse/Validator/Constraints/I18n/GreaterThanOrEqual.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual as ParentConstraint;
+
+class GreaterThanOrEqual extends ParentConstraint
+{
+    public $message = 'MUST_BE_GREATER_THAN_OR_EQUAL';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Iban.php
+++ b/src/Synapse/Validator/Constraints/I18n/Iban.php
@@ -10,6 +10,6 @@ class Iban extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\IbanValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Iban.php
+++ b/src/Synapse/Validator/Constraints/I18n/Iban.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Iban as ParentConstraint;
+
+class Iban extends ParentConstraint
+{
+    public $message = 'INVALID_IBAN';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\IbanValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/IdenticalTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/IdenticalTo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\IdenticalTo as ParentConstraint;
+
+class IdenticalTo extends ParentConstraint
+{
+    public $message = 'MUST_BE_IDENTICAL_TO';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\IdenticalToValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/IdenticalTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/IdenticalTo.php
@@ -10,6 +10,6 @@ class IdenticalTo extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\IdenticalToValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Image.php
+++ b/src/Synapse/Validator/Constraints/I18n/Image.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Image as ParentConstraint;
+
+class Image extends ParentConstraint
+{
+    public $mimeTypesMessage       = 'NOT_VALID_IMAGE';
+    public $sizeNotDetectedMessage = 'IMAGE_SIZE_NOT_DETECTED';
+    public $maxWidthMessage        = 'IMAGE_EXCEEDS_MAX_WIDTH';
+    public $minWidthMessage        = 'IMAGE_DOES_NOT_MEET_MIN_WIDTH';
+    public $maxHeightMessage       = 'IMAGE_EXCEEDS_MAX_HEIGHT';
+    public $minHeightMessage       = 'IMAGE_DOES_NOT_MEET_MIN_HEIGHT';
+    public $maxRatioMessage        = 'IMAGE_EXCEEDS_MAX_RATIO';
+    public $minRatioMessage        = 'IMAGE_DOES_NOT_MEET_MIN_RATIO';
+    public $allowSquareMessage     = 'IMAGE_MUST_NOT_BE_SQUARE';
+    public $allowLandscapeMessage  = 'IMAGE_MUST_NOT_BE_LANDSCAPE';
+    public $allowPortraitMessage   = 'IMAGE_MUST_NOT_BE_PORTRAIT';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\ImageValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Image.php
+++ b/src/Synapse/Validator/Constraints/I18n/Image.php
@@ -20,6 +20,6 @@ class Image extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\ImageValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Ip.php
+++ b/src/Synapse/Validator/Constraints/I18n/Ip.php
@@ -10,6 +10,6 @@ class Ip extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\IpValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Ip.php
+++ b/src/Synapse/Validator/Constraints/I18n/Ip.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Ip as ParentConstraint;
+
+class Ip extends ParentConstraint
+{
+    public $message = 'INVALID_IP_ADDRESS';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\IpValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Isbn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Isbn.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Isbn as ParentConstraint;
+
+class Isbn extends ParentConstraint
+{
+    public $isbn10Message   = 'INVALID_ISBN_10.';
+    public $isbn13Message   = 'INVALID_ISBN_13';
+    public $bothIsbnMessage = 'INVALID_ISBN';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\IsbnValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Isbn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Isbn.php
@@ -6,7 +6,7 @@ use Symfony\Component\Validator\Constraints\Isbn as ParentConstraint;
 
 class Isbn extends ParentConstraint
 {
-    public $isbn10Message   = 'INVALID_ISBN_10.';
+    public $isbn10Message   = 'INVALID_ISBN_10';
     public $isbn13Message   = 'INVALID_ISBN_13';
     public $bothIsbnMessage = 'INVALID_ISBN';
 

--- a/src/Synapse/Validator/Constraints/I18n/Isbn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Isbn.php
@@ -12,6 +12,6 @@ class Isbn extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\IsbnValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Issn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Issn.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Issn as ParentConstraint;
+
+class Issn extends ParentConstraint
+{
+    public $message = 'INVALID_ISSN';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\IssnValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Issn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Issn.php
@@ -10,6 +10,6 @@ class Issn extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\IssnValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Language.php
+++ b/src/Synapse/Validator/Constraints/I18n/Language.php
@@ -10,6 +10,6 @@ class Language extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\LanguageValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Language.php
+++ b/src/Synapse/Validator/Constraints/I18n/Language.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Language as ParentConstraint;
+
+class Language extends ParentConstraint
+{
+    public $message = 'INVALID_LANGUAGE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\LanguageValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Length.php
+++ b/src/Synapse/Validator/Constraints/I18n/Length.php
@@ -12,6 +12,6 @@ class Length extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\LengthValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Length.php
+++ b/src/Synapse/Validator/Constraints/I18n/Length.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Length as ParentConstraint;
+
+class Length extends ParentConstraint
+{
+    public $maxMessage   = 'VALUE_TOO_LONG';
+    public $minMessage   = 'VALUE_TOO_SHORT';
+    public $exactMessage = 'VALUE_NOT_EXACT_LENGTH';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\LengthValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/LessThan.php
+++ b/src/Synapse/Validator/Constraints/I18n/LessThan.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\LessThan as ParentConstraint;
+
+class LessThan extends ParentConstraint
+{
+    public $message = 'MUST_BE_LESS_THAN';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\LessThanValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/LessThan.php
+++ b/src/Synapse/Validator/Constraints/I18n/LessThan.php
@@ -10,6 +10,6 @@ class LessThan extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\LessThanValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/LessThanOrEqual.php
+++ b/src/Synapse/Validator/Constraints/I18n/LessThanOrEqual.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\LessThanOrEqual as ParentConstraint;
+
+class LessThanOrEqual extends ParentConstraint
+{
+    public $message = 'MUST_BE_LESS_THAN_OR_EQUAL';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\LessThanOrEqualValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/LessThanOrEqual.php
+++ b/src/Synapse/Validator/Constraints/I18n/LessThanOrEqual.php
@@ -10,6 +10,6 @@ class LessThanOrEqual extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\LessThanOrEqualValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Locale.php
+++ b/src/Synapse/Validator/Constraints/I18n/Locale.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Locale as ParentConstraint;
+
+class Locale extends ParentConstraint
+{
+    public $message = 'INVALID_LOCALE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\LocaleValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Locale.php
+++ b/src/Synapse/Validator/Constraints/I18n/Locale.php
@@ -10,6 +10,6 @@ class Locale extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\LocaleValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Luhn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Luhn.php
@@ -10,6 +10,6 @@ class Luhn extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\LuhnValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Luhn.php
+++ b/src/Synapse/Validator/Constraints/I18n/Luhn.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Luhn as ParentConstraint;
+
+class Luhn extends ParentConstraint
+{
+    public $message = 'INVALID_CARD_NUMBER';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\LuhnValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/NotBlank.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotBlank.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\NotBlank as ParentConstraint;
+
+class NotBlank extends ParentConstraint
+{
+    public $message = 'MUST_NOT_BE_BLANK';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\NotBlankValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/NotBlank.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotBlank.php
@@ -10,6 +10,6 @@ class NotBlank extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\NotBlankValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/NotEqualTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotEqualTo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\NotEqualTo as ParentConstraint;
+
+class NotEqualTo extends ParentConstraint
+{
+    public $message = 'MUST_NOT_BE_EQUAL_TO';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\NotEqualToValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/NotEqualTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotEqualTo.php
@@ -10,6 +10,6 @@ class NotEqualTo extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\NotEqualToValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/NotIdenticalTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotIdenticalTo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\NotIdenticalTo as ParentConstraint;
+
+class NotIdenticalTo extends ParentConstraint
+{
+    public $message = 'MUST_NOT_BE_IDENTICAL_TO';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\NotIdenticalToValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/NotIdenticalTo.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotIdenticalTo.php
@@ -10,6 +10,6 @@ class NotIdenticalTo extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\NotIdenticalToValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/NotNull.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotNull.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\NotNull as ParentConstraint;
+
+class NotNull extends ParentConstraint
+{
+    public $message = 'MUST_NOT_BE_NULL';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\NotNullValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/NotNull.php
+++ b/src/Synapse/Validator/Constraints/I18n/NotNull.php
@@ -10,6 +10,6 @@ class NotNull extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\NotNullValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Null.php
+++ b/src/Synapse/Validator/Constraints/I18n/Null.php
@@ -10,6 +10,6 @@ class Null extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\NullValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Null.php
+++ b/src/Synapse/Validator/Constraints/I18n/Null.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Null as ParentConstraint;
+
+class Null extends ParentConstraint
+{
+    public $message = 'MUST_BE_NULL';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\NullValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Range.php
+++ b/src/Synapse/Validator/Constraints/I18n/Range.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Range as ParentConstraint;
+
+class Range extends ParentConstraint
+{
+    public $minMessage     = 'BELOW_RANGE';
+    public $maxMessage     = 'BEYOND_RANGE';
+    public $invalidMessage = 'NOT_A_NUMBER';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\RangeValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Range.php
+++ b/src/Synapse/Validator/Constraints/I18n/Range.php
@@ -12,6 +12,6 @@ class Range extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\RangeValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Regex.php
+++ b/src/Synapse/Validator/Constraints/I18n/Regex.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Regex as ParentConstraint;
+
+class Regex extends ParentConstraint
+{
+    public $message = 'INVALID_VALUE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\RegexValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Regex.php
+++ b/src/Synapse/Validator/Constraints/I18n/Regex.php
@@ -10,6 +10,6 @@ class Regex extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\RegexValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/RowExists.php
+++ b/src/Synapse/Validator/Constraints/I18n/RowExists.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Synapse\Validator\Constraints\RowExists as ParentConstraint;
+
+class RowExists extends ParentConstraint
+{
+    public $message = 'ROW_DOES_NOT_EXIST';
+
+    // Message to use if we're using the 'field' option
+    const FIELD_MESSAGE = 'ROW_DOES_NOT_EXIST_WITH_FIELD_EQUAL_TO';
+
+    public function validatedBy()
+    {
+        return 'Synapse\Validator\COnstraints\RowExistsValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/RowNotExists.php
+++ b/src/Synapse/Validator/Constraints/I18n/RowNotExists.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Synapse\Validator\Constraints\RowNotExists as ParentConstraint;
+
+class RowNotExists extends ParentConstraint
+{
+    public $message = 'ROW_EXISTS';
+
+    // Message to use if we're using the 'field' option
+    const FIELD_MESSAGE = 'ROW_EXISTS_WITH_FIELD_EQUAL_TO';
+
+    public function validatedBy()
+    {
+        return 'Synapse\Validator\COnstraints\RowNotExistsValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/RowsExist.php
+++ b/src/Synapse/Validator/Constraints/I18n/RowsExist.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Synapse\Validator\Constraints\I18n\RowExists as ParentConstraint;
+
+class RowsExist extends ParentConstraint
+{
+    public function validatedBy()
+    {
+        return 'Synapse\Validator\Constraints\RowsExistValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Time.php
+++ b/src/Synapse/Validator/Constraints/I18n/Time.php
@@ -10,6 +10,6 @@ class Time extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\TimeValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Time.php
+++ b/src/Synapse/Validator/Constraints/I18n/Time.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Time as ParentConstraint;
+
+class Time extends ParentConstraint
+{
+    public $message = 'INVALID_TIME';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\TimeValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/True.php
+++ b/src/Synapse/Validator/Constraints/I18n/True.php
@@ -10,6 +10,6 @@ class True extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\TrueValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/True.php
+++ b/src/Synapse/Validator/Constraints/I18n/True.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\True as ParentConstraint;
+
+class True extends ParentConstraint
+{
+    public $message = 'MUST_BE_TRUE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\TrueValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Type.php
+++ b/src/Synapse/Validator/Constraints/I18n/Type.php
@@ -10,6 +10,6 @@ class Type extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\TypeValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Type.php
+++ b/src/Synapse/Validator/Constraints/I18n/Type.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Type as ParentConstraint;
+
+class Type extends ParentConstraint
+{
+    public $message = 'MUST_BE_TYPE';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\TypeValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Url.php
+++ b/src/Synapse/Validator/Constraints/I18n/Url.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Url as ParentConstraint;
+
+class Url extends ParentConstraint
+{
+    public $message = 'INVALID_URL';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\UrlValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Url.php
+++ b/src/Synapse/Validator/Constraints/I18n/Url.php
@@ -10,6 +10,6 @@ class Url extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\UrlValidator';
+        return parent::class + 'Validator';
     }
 }

--- a/src/Synapse/Validator/Constraints/I18n/Uuid.php
+++ b/src/Synapse/Validator/Constraints/I18n/Uuid.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Synapse\Validator\Constraints\I18n;
+
+use Symfony\Component\Validator\Constraints\Uuid as ParentConstraint;
+
+class Uuid extends ParentConstraint
+{
+    public $message = 'INVALID_UUID';
+
+    public function validatedBy()
+    {
+        return 'Symfony\Component\Validator\Constraints\UuidValidator';
+    }
+}

--- a/src/Synapse/Validator/Constraints/I18n/Uuid.php
+++ b/src/Synapse/Validator/Constraints/I18n/Uuid.php
@@ -10,6 +10,6 @@ class Uuid extends ParentConstraint
 
     public function validatedBy()
     {
-        return 'Symfony\Component\Validator\Constraints\UuidValidator';
+        return parent::class + 'Validator';
     }
 }


### PR DESCRIPTION
### Acceptance Criteria
1. Validation errors in api returns constants + variables (which may require some modifications on the front-end i18n stuff to properly render strings like "The string must be [number] characters long" for proper formatting)
1. Validator errors should be constants on the corresponding class, not a string variable.

### Tasks
- Extend all existing validators to properly return the above

### Additional Notes
- None
