### PR TITLE
UserEntity's `enabled` and `verified` values should be set as booleans 

### DIFF
--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -154,11 +154,11 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
         }
 
         // If enabled in config, check that user is verified
-        if ($this->requireVerification && $user->getVerified() !== '1') {
+        if ($this->requireVerification && ! $user->getVerified()) {
             return $this->createInvalidCredentialResponse();
         }
 
-        if ($user->getEnabled() !== '1') {
+        if (! $user->getEnabled()) {
             return $this->createInvalidCredentialResponse();
         }
 

--- a/src/Synapse/User/UserEntity.php
+++ b/src/Synapse/User/UserEntity.php
@@ -54,6 +54,16 @@ class UserEntity extends AbstractEntity implements UserInterface
         return $this;
     }
 
+    public function setEnabled($value)
+    {
+        return $this->setAsBoolean('enabled', $value);
+    }
+
+    public function setVerified($value)
+    {
+        return $this->setAsBoolean('verified', $value);
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
It makes no sense for them to be strings. We should be able to write `if ($user->getEnabled())...`.

Will need to update [here](https://github.com/synapsestudios/synapse-base/blob/master/src/Synapse/OAuth2/OAuthController.php#L157) and [here](https://github.com/synapsestudios/synapse-base/blob/master/src/Synapse/OAuth2/OAuthController.php#L161).