### PR TITLE
Silex causes requests with expired access tokens to be 302 redirected to /login

### DIFF
--- a/src/Synapse/Security/Firewall/OAuth2OptionalListener.php
+++ b/src/Synapse/Security/Firewall/OAuth2OptionalListener.php
@@ -4,6 +4,7 @@ namespace Synapse\Security\Firewall;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Synapse\Security\Authentication\OAuth2UserToken;
 
 /**


### PR DESCRIPTION
When hitting a route with `oauth-optional` set in the firewalls and the frontend having an expired oauth token, Silex will redirect to `/login`. The frontend gets confused and sad. It should instead return an unauthorized error so the frontend can request a new token.

### Clues

It redirects to login because that's the default `login_path` set in `Silex\Provider\SecurityServiceProvider`.

We don't want to "fix" this path -- we just want to prevent the OauthOptional listener from redirecting to the login path in the first place.