### PR TITLE
Required verification config setting doesn't work on token endpoint

### DIFF
--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -206,6 +206,20 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
     {
         $bridgeResponse = new BridgeResponse;
         $oauthRequest   = OAuthRequest::createFromRequest($request);
+        $user           = $this->getUserFromRequest($request);
+
+        if (! $user) {
+            return $this->createInvalidCredentialResponse();
+        }
+
+        // If enabled in config, check that user is verified
+        if ($this->requireVerification && ! $user->getVerified()) {
+            return $this->createInvalidCredentialResponse();
+        }
+
+        if (! $user->getEnabled()) {
+            return $this->createInvalidCredentialResponse();
+        }
 
         $response = $this->server->handleTokenRequest($oauthRequest, $bridgeResponse);
 


### PR DESCRIPTION
## Description

When you set requireVerificiation=true in the app config, it applies to the HTML login form endpoint (eg, Lively) but not to the token endpoint that the frontend uses to authenticate. This check should be done here as well.