### PR TITLE
Fix user verification bug

### DIFF
--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -149,6 +149,10 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
     {
         $user = $this->getUserFromRequest($request);
 
+        if (! $user) {
+            return $this->createInvalidCredentialResponse();
+        }
+
         $attemptedPassword = $request->get('password');
         $hashedPassword    = $user->getPassword();
 

--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -206,24 +206,24 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
     {
         $bridgeResponse = new BridgeResponse;
         $oauthRequest   = OAuthRequest::createFromRequest($request);
-        $user           = $this->getUserFromRequest($request);
-
-        if (! $user) {
-            return $this->createInvalidCredentialResponse();
-        }
-
-        // If enabled in config, check that user is verified
-        if ($this->requireVerification && ! $user->getVerified()) {
-            return $this->createInvalidCredentialResponse();
-        }
-
-        if (! $user->getEnabled()) {
-            return $this->createInvalidCredentialResponse();
-        }
-
-        $response = $this->server->handleTokenRequest($oauthRequest, $bridgeResponse);
+        $response       = $this->server->handleTokenRequest($oauthRequest, $bridgeResponse);
 
         if ($response->isOk()) {
+            $user = $this->userService->findById($response->getParameter('user_id'));
+
+            if (! $user) {
+                return $this->createInvalidCredentialResponse();
+            }
+
+            // If enabled in config, check that user is verified
+            if ($this->requireVerification && ! $user->getVerified()) {
+                return $this->createInvalidCredentialResponse();
+            }
+
+            if (! $user->getEnabled()) {
+                return $this->createInvalidCredentialResponse();
+            }
+
             $userId = $response->getParameter('user_id');
 
             $this->setLastLogin($userId);

--- a/src/Synapse/OAuth2/OAuthController.php
+++ b/src/Synapse/OAuth2/OAuthController.php
@@ -149,19 +149,6 @@ class OAuthController extends AbstractController implements SecurityAwareInterfa
     {
         $user = $this->getUserFromRequest($request);
 
-        if (! $user) {
-            return $this->createInvalidCredentialResponse();
-        }
-
-        // If enabled in config, check that user is verified
-        if ($this->requireVerification && ! $user->getVerified()) {
-            return $this->createInvalidCredentialResponse();
-        }
-
-        if (! $user->getEnabled()) {
-            return $this->createInvalidCredentialResponse();
-        }
-
         $attemptedPassword = $request->get('password');
         $hashedPassword    = $user->getPassword();
 

--- a/tests/Test/Synapse/OAuth2/OAuthControllerTest.php
+++ b/tests/Test/Synapse/OAuth2/OAuthControllerTest.php
@@ -294,48 +294,6 @@ class OAuthControllerTest extends ControllerTestCase
         ]);
     }
 
-    public function testAuthorizeFormSubmitDoesNotAuthorizeUnverifiedUser()
-    {
-        $userId   = 123;
-        $password = 'foo';
-
-        $this->mockOAuth2Server->expects($this->never())
-            ->method('handleAuthorizeRequest')
-            ->with(
-                $this->isInstanceOf('OAuth2\HttpFoundationBridge\Request'),
-                $this->isInstanceOf('OAuth2\HttpFoundationBridge\Response'),
-                $this->equalTo(true),
-                $this->equalTo($userId)
-            );
-
-        $this->withUserFoundHavingPassword($password, ['id' => $userId, 'verified' => '0']);
-
-        $this->performPostRequestToAuthorizeFormSubmit([
-            'password' => $password,
-        ]);
-    }
-
-    public function testAuthorizeFormSubmitDoesNotAuthorizeDisabledUser()
-    {
-        $userId   = 123;
-        $password = 'foo';
-
-        $this->mockOAuth2Server->expects($this->never())
-            ->method('handleAuthorizeRequest')
-            ->with(
-                $this->isInstanceOf('OAuth2\HttpFoundationBridge\Request'),
-                $this->isInstanceOf('OAuth2\HttpFoundationBridge\Response'),
-                $this->equalTo(true),
-                $this->equalTo($userId)
-            );
-
-        $this->withUserFoundHavingPassword($password, ['id' => $userId, 'enabled' => '0']);
-
-        $this->performPostRequestToAuthorizeFormSubmit([
-            'password' => $password,
-        ]);
-    }
-
     public function testAuthorizeFormSubmitConvertsPostParamsToGetParamsInRequestSentToOauthServer()
     {
         $this->withUserFoundHavingPassword('pa55');


### PR DESCRIPTION
The token request response should be checked first, then we can look up the status of the user. The Lively form also calls this token function as part of the authentication flow, so we don't need to do it in two places.