### PR TITLE
Allow rollbar error level to be set in configuration

### DIFF
--- a/src/Synapse/Log/LogServiceProvider.php
+++ b/src/Synapse/Log/LogServiceProvider.php
@@ -175,23 +175,6 @@ class LogServiceProvider implements ServiceProviderInterface
     protected function getRollbarHandler($environment)
     {
         $rollbarConfig = Arr::get($this->config, 'rollbar', []);
-
-        $token = Arr::get($rollbarConfig, 'post_server_item_access_token');
-
-        if (! $token) {
-            throw new ConfigException('Rollbar is enabled but the post server item access token is not set.');
-        }
-
-        $rollbarNotifier = new RollbarNotifier([
-            'access_token' => $token,
-            'environment'  => $environment,
-            'batched'      => false,
-            'root'         => Arr::get($rollbarConfig, 'root')
-        ]);
-
-        return new RollbarHandler(
-            $rollbarNotifier,
-            Logger::ERROR
-        );
+        return new RollbarHandler($rollbarConfig, $environment);
     }
 }


### PR DESCRIPTION
## Allow rollbar error level to be set in configuration

### Acceptance Criteria
1. The log threshold for rollbar can be provided by the rollbar configuration
1. if no log threshold is provided in configuration the default to `Logger::ERROR`

### Notes
This probably should be done more generally for all our log handlers but I'm not super into doing that right now