### PR TITLE
Add Beta Environment

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -11,7 +11,7 @@ before_script:
   - composer self-update
   - composer install --prefer-source
 script:
-  - APP_ENV=testing vendor/bin/phpunit --configuration phpunit.shippable.xml
+  - vendor/bin/phpunit --configuration phpunit.shippable.xml
   - vendor/bin/phpcs --standard=PSR2 src/*
 notifications:
   email: false

--- a/shippable.yml
+++ b/shippable.yml
@@ -11,7 +11,7 @@ before_script:
   - composer self-update
   - composer install --prefer-source
 script:
-  - vendor/bin/phpunit --configuration phpunit.shippable.xml
+  - APP_ENV=testing vendor/bin/phpunit --configuration phpunit.shippable.xml
   - vendor/bin/phpcs --standard=PSR2 src/*
 notifications:
   email: false

--- a/shippable.yml
+++ b/shippable.yml
@@ -5,7 +5,7 @@ git:
   submodules: false
 env:
   global:
-    - SLACK_ORG=synapse PROJECT=synapse-base
+    - SLACK_ORG=synapse PROJECT=synapse-base APP_ENV=testing
     - secure: 2AZyPbC1I1Tp94w5fUvv9UXdCuzmpW4b0s8phVEzcxsCeney5oclGsXPQ5IPFV99NROLg8+dN7y0iQC5mGkgz78zSExL+JHgthbUHC5MGpCwRc8P6qI50SMFkt0oMsJfEL2hZJakRX6qC5kWvafiF7YoMz32HAcBQBKeZUManaGjdHqb21sKGmujFagmpHNFY2YgHr942nBhn+cppmsEvKSZeHqI3R2W1RLD2QPGBeyWEtEhU9tQWO7ll8oghA/Kc7gxNFBd76SCcAk5o5SSxJpyoXp8BpDe6p2quj7qpfkhYao3gdQm+SfPJJP2XdZb738gyVJFnwgaEBj+O6/kAw==
 before_script:
   - composer self-update

--- a/src/Synapse/ApplicationInitializer.php
+++ b/src/Synapse/ApplicationInitializer.php
@@ -53,12 +53,15 @@ class ApplicationInitializer
             'development',
         );
 
-        // Detect the current application environment
-        if (isset($_SERVER['APP_ENV']) && in_array($_SERVER['APP_ENV'], $environments)) {
-            $app['environment'] = $_SERVER['APP_ENV'];
-        } else {
-            $app['environment'] = 'development';
+        if (! isset($_SERVER['APP_ENV'])) {
+            throw new \Exception('Missing \'APP_ENV\' environment variable');
         }
+
+        if (! in_array($_SERVER['APP_ENV'], $environments)) {
+            throw new \Exception('Invalid \'APP_ENV\' environment variable: \'' + $_SERVER['APP_ENV'] +'\'');
+        }
+
+        $app['environment'] = $_SERVER['APP_ENV'];
     }
 
     /**

--- a/src/Synapse/ApplicationInitializer.php
+++ b/src/Synapse/ApplicationInitializer.php
@@ -51,6 +51,7 @@ class ApplicationInitializer
             'qa',
             'testing',
             'development',
+            'beta',
         );
 
         if (! isset($_SERVER['APP_ENV'])) {


### PR DESCRIPTION
## Allow `beta` as an environment

### Acceptance Criteria
1. Environment can be set to `beta`
1. If `APP_ENV` isn't set or isn't one of the available options, throw an exception
