### PR TITLE
Add missing use statement to RollbarHandler

### DIFF
--- a/src/Synapse/Log/Handler/RollbarHandler.php
+++ b/src/Synapse/Log/Handler/RollbarHandler.php
@@ -3,6 +3,7 @@
 namespace Synapse\Log\Handler;
 
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
 use RollbarNotifier;
 use Exception;
 use Synapse\Config\Exception as ConfigException;


### PR DESCRIPTION
```
==> default: STDERR: PHP Fatal error:  Class 'Synapse\Log\Handler\Logger' not found in /vagrant/vendor/synapsestudios/synapse-base/src/Synapse/Log/Handler/RollbarHandler.php on line 45
==> default: PHP Stack trace:
==> default: PHP   1. {main}() /vagrant/console:0
==> default: PHP   2. require() /vagrant/console:16
==> default: PHP   3. Synapse\Application\Services->register() /vagrant/bootstrap.php:35
==> default: PHP   4. Silex\Application->register() /vagrant/vendor/synapsestudios/synapse-base/src/Synapse/Application/Services.php:18
==> default: PHP   5. Synapse\Log\LogServiceProvider->register() /vagrant/vendor/silex/silex/src/Silex/Application.php:169
==> default: PHP   6. Synapse\Log\LogServiceProvider->getHandlers() /vagrant/vendor/synapsestudios/synapse-base/src/Synapse/Log/LogServiceProvider.php:43
==> default: PHP   7. Synapse\Log\LogServiceProvider->getRollbarHandler() /vagrant/vendor/synapsestudios/synapse-base/src/Synapse/Log/LogServiceProvider.php:97
==> default: PHP   8. Synapse\Log\Handler\RollbarHandler->__construct() /vagrant/vendor/synapsestudios/synapse-base/src/Synapse/Log/LogServiceProvider.php:178
==> default: ---- End output of   ./console install:run
```