### PR TITLE
InserterTrait: LogicException: 0 when autoIncrement column is missing

### DIFF
--- a/src/Synapse/Mapper/InserterTrait.php
+++ b/src/Synapse/Mapper/InserterTrait.php
@@ -48,7 +48,7 @@ trait InserterTrait
         $columns = array_keys($values);
 
         if ($this->autoIncrementColumn && ! array_key_exists($this->autoIncrementColumn, $values)) {
-            throw new LogicException('auto_increment column ' + $this->autoIncrementColumn + ' not found');
+            throw new LogicException('auto_increment column ' . $this->autoIncrementColumn . ' not found');
         }
 
         $query = $this->getSqlObject()


### PR DESCRIPTION
## Description
The error message for when the autoIncrement column is missing from an entity is `0`

https://github.com/synapsestudios/synapse-base/blob/master/src/Synapse/Mapper/InserterTrait.php#L51