### PR TITLE
Mapper update method should only update changed fields

### DIFF
--- a/src/Synapse/Mapper/UpdaterTrait.php
+++ b/src/Synapse/Mapper/UpdaterTrait.php
@@ -48,4 +48,39 @@ trait UpdaterTrait
 
         $this->execute($query);
     }
+
+    public function patch(AbstractEntity $entity) {
+        if ($this->updatedTimestampColumn) {
+            $entity->exchangeArray([$this->updatedTimestampColumn => time()]);
+        }
+
+        if ($this->updatedDatetimeColumn) {
+            $entity->exchangeArray([$this->updatedDatetimeColumn => date('Y-m-d H:i:s')]);
+        }
+
+        $this->patchRow($entity);
+
+        return $entity;
+    }
+
+    /**
+     * Update an entity's DB row by its ID.
+     * Set the updated timestamp column if it exists.
+     *
+     * @param  AbstractEntity $entity
+     */
+    protected function patchRow(AbstractEntity $entity)
+    {
+        $values = $entity->getChangedDbValues();
+        if (empty($values)) {
+            return;
+        }
+
+        $query = $this->getSqlObject()
+            ->update()
+            ->set($values)
+            ->where($this->getPrimaryKeyWheres($entity));
+
+        $this->execute($query);
+    }
 }

--- a/src/Synapse/Mapper/UpdaterTrait.php
+++ b/src/Synapse/Mapper/UpdaterTrait.php
@@ -49,7 +49,8 @@ trait UpdaterTrait
         $this->execute($query);
     }
 
-    public function patch(AbstractEntity $entity) {
+    public function patch(AbstractEntity $entity)
+    {
         if ($this->updatedTimestampColumn) {
             $entity->exchangeArray([$this->updatedTimestampColumn => time()]);
         }

--- a/src/Synapse/TestHelper/MapperTestCase.php
+++ b/src/Synapse/TestHelper/MapperTestCase.php
@@ -53,6 +53,8 @@ abstract class MapperTestCase extends TestCase
     protected $mockResults = [];
 
     protected $fallbackTableName = 'table';
+    protected $mockResultCount;
+    private $mapper;
 
     public function setUp()
     {
@@ -70,7 +72,7 @@ abstract class MapperTestCase extends TestCase
     /**
      * Set array of data that a query result will contain
      *
-     * @param array $results... Array of data for result to contain.  Repeatable
+     * @internal param array $results ... Array of data for result to contain.  Repeatable
      *                          if multiple queries will be executed.
      */
     public function setMockResults()

--- a/src/Synapse/TestHelper/WebTestCase.php
+++ b/src/Synapse/TestHelper/WebTestCase.php
@@ -58,6 +58,9 @@ class WebTestCase extends WebCase
         defined('DATADIR') or define('DATADIR', APPDIR.'/data');
         defined('TMPDIR') or define('TMPDIR', '/tmp');
         date_default_timezone_set('UTC');
+        if (!array_key_exists('APP_ENV', $_SERVER)) {
+            $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = 'development';
+        }
 
         $applicationInitializer = new Synapse\ApplicationInitializer;
 

--- a/tests/Test/Synapse/Mapper/UpdaterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/UpdaterTraitTest.php
@@ -2,11 +2,32 @@
 
 namespace Test\Synapse\Mapper;
 
+use Synapse\Mapper\AbstractMapper;
+use Synapse\Mapper\UpdaterTrait;
 use Synapse\TestHelper\MapperTestCase;
 use Synapse\User\UserEntity;
 
 class UpdaterTraitTest extends MapperTestCase
 {
+    private $prototype;
+    private $timestampPrototype;
+    /**
+     * @var AbstractMapper|UpdaterTrait
+     */
+    private $mapper;
+    /**
+     * @var AbstractMapper|UpdaterTrait
+     */
+    private $timestampMapper;
+    /**
+     * @var AbstractMapper|UpdaterTrait
+     */
+    private $datetimeMapper;
+    /**
+     * @var AbstractMapper|UpdaterTrait
+     */
+    private $differentPrimaryKeyMapper;
+
     public function setUp()
     {
         parent::setUp();
@@ -173,6 +194,28 @@ class UpdaterTraitTest extends MapperTestCase
                 $keyValues['id'],
                 $keyValues['email']
             )
+        );
+    }
+
+    public function testPatchOnMapperWithNoChangesDoesNotCallExecute()
+    {
+        $entity = $this->createEntityToUpdate();
+
+        $this->mapper->patch($entity);
+
+        $this->assertEmpty($this->sqlStrings);
+    }
+
+    public function testPatchOnMapperWithOneChangeDoesNotUpdateOtherField()
+    {
+        $entity = $this->createEntityToUpdate();
+        $entity->setEmail('x@y.com');
+
+        $this->mapper->patch($entity);
+
+        $this->assertEquals(
+            "UPDATE `test_table` SET `email` = 'x@y.com' WHERE `id` = '1234'",
+            $this->getSqlString(0)
         );
     }
 }


### PR DESCRIPTION
Currently, an update call overwrites all data in a record.  Doing this can easily cause race conditions if two different api calls changes different fields in the same record.
To do this properly, we should keep track of "dirty" fields and only update those that have changed.