### PR TITLE
Hydrating marks properties as dirty

### DIFF
--- a/src/Synapse/Entity/AbstractEntity.php
+++ b/src/Synapse/Entity/AbstractEntity.php
@@ -97,6 +97,15 @@ abstract class AbstractEntity extends DataObject implements AbstractEntityInterf
     }
 
     /**
+     * Sets entity as clean
+     * This should *ONLY* be used by a hydrator
+     */
+    public function setAsClean()
+    {
+        $this->dirtyFields = [];
+    }
+
+    /**
      * Set the given field with the given value typecasted as an integer
      *
      * @param string $field Field to set

--- a/src/Synapse/Mapper/AbstractMapper.php
+++ b/src/Synapse/Mapper/AbstractMapper.php
@@ -4,7 +4,7 @@ namespace Synapse\Mapper;
 
 use ArrayObject;
 
-use Synapse\Stdlib\Arr;
+use Synapse\Mapper\Hydrator\ArraySerializable;
 use Synapse\Entity\AbstractEntity as AbstractEntity;
 use Synapse\Entity\EntityIterator;
 use Synapse\Db\ResultSet\HydratingResultSet;
@@ -15,7 +15,6 @@ use Zend\Db\Sql\Sql;
 use Zend\Db\Sql\PreparableSqlInterface;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Stdlib\Hydrator\HydratorInterface;
-use Zend\Stdlib\Hydrator\ArraySerializable;
 
 /**
  * An abstract class for mapping database records to entity objects
@@ -41,7 +40,7 @@ abstract class AbstractMapper implements LoggerAwareInterface
     /**
      * Entity prototype used to return hydrated entities
      *
-     * @var Entity
+     * @var AbstractEntity
      */
     protected $prototype;
 
@@ -55,7 +54,7 @@ abstract class AbstractMapper implements LoggerAwareInterface
     /**
      * The hydrator used to create entities from database results
      *
-     * @var Zend\Stdlib\Hydrator\HydratorInterface
+     * @var HydratorInterface
      */
     protected $hydrator;
 
@@ -113,7 +112,7 @@ abstract class AbstractMapper implements LoggerAwareInterface
     /**
      * Set injected objects as properties
      *
-     * @param DbAdapter      $db        Query builder object
+     * @param DbAdapter      $dbAdapter Query builder object
      * @param AbstractEntity $prototype Entity prototype
      */
     public function __construct(DbAdapter $dbAdapter, AbstractEntity $prototype = null)
@@ -160,10 +159,12 @@ abstract class AbstractMapper implements LoggerAwareInterface
      */
     public function persist(AbstractEntity $entity)
     {
+        /** @var InserterTrait $this */
         if ($entity->isNew()) {
             return $this->insert($entity);
         }
 
+        /** @var UpdaterTrait $this */
         return $this->update($entity);
     }
 
@@ -181,6 +182,7 @@ abstract class AbstractMapper implements LoggerAwareInterface
      * Set the entity prototype for this mapper
      *
      * @param AbstractEntity $prototype
+     * @return $this
      */
     public function setPrototype(AbstractEntity $prototype)
     {
@@ -229,7 +231,7 @@ abstract class AbstractMapper implements LoggerAwareInterface
      * Execute a given query
      *
      * @param  PreparableSqlInterface $query Query to be executed
-     * @return Zend\Db\ResultSet\ResultSet
+     * @return HydratingResultSet
      */
     protected function execute(PreparableSqlInterface $query)
     {

--- a/src/Synapse/Mapper/FinderTrait.php
+++ b/src/Synapse/Mapper/FinderTrait.php
@@ -126,8 +126,8 @@ trait FinderTrait
     /**
      * Find all entities in this table
      *
-     * @param  array $options Array of options for this request
-     * @return array          Array of AbstractEntity objects
+     * @param  array $options           Array of options for this request
+     * @return array|EntityIterator Array of AbstractEntity objects
      */
     public function findAll(array $options = [])
     {

--- a/src/Synapse/Mapper/Hydrator/ArraySerializable.php
+++ b/src/Synapse/Mapper/Hydrator/ArraySerializable.php
@@ -1,0 +1,15 @@
+<?php
+namespace Synapse\Mapper\Hydrator;
+
+class ArraySerializable extends \Zend\Stdlib\Hydrator\ArraySerializable
+{
+    public function hydrate(array $data, $object)
+    {
+        $object = parent::hydrate($data, $object);
+        if (is_callable([$object, 'setAsClean'])) {
+            $object->setAsClean();
+        }
+
+        return $object;
+    }
+}

--- a/src/Synapse/TestHelper/MapperTestCase.php
+++ b/src/Synapse/TestHelper/MapperTestCase.php
@@ -54,7 +54,7 @@ abstract class MapperTestCase extends TestCase
 
     protected $fallbackTableName = 'table';
     protected $mockResultCount;
-    private $mapper;
+    protected $mapper;
 
     public function setUp()
     {

--- a/tests/Test/Synapse/Mapper/FinderTraitTest.php
+++ b/tests/Test/Synapse/Mapper/FinderTraitTest.php
@@ -2,8 +2,9 @@
 
 namespace Test\Synapse\Mapper;
 
+use Synapse\Mapper\AbstractMapper;
+use Synapse\Mapper\FinderTrait;
 use Synapse\TestHelper\MapperTestCase;
-use Synapse\User\UserEntity;
 use stdClass;
 
 class FinderTraitTest extends MapperTestCase
@@ -13,6 +14,10 @@ class FinderTraitTest extends MapperTestCase
 
     // Set to a non-round number to make the tests stronger
     const RESULTS_PER_PAGE = 47;
+    /** @var  AbstractMapper|FinderTrait */
+    protected $mapper;
+    private $prototype;
+    private $captured;
 
     public function setUp()
     {
@@ -22,7 +27,9 @@ class FinderTraitTest extends MapperTestCase
 
         $this->prototype = $this->createPrototype();
 
+        /** @noinspection PhpParamsInspection */
         $this->mapper = new Mapper($this->mocks['adapter'], $this->prototype);
+        /** @noinspection PhpParamsInspection */
         $this->mapper->setSqlFactory($this->mocks['sqlFactory']);
 
         $this->mapper->setResultsPerPage(self::RESULTS_PER_PAGE);
@@ -134,8 +141,6 @@ class FinderTraitTest extends MapperTestCase
 
     public function testFindByConstructsWhereClausesWithAnds()
     {
-        $tableName = $this->mapper->getTableName();
-
         $constraints = $this->createSearchConstraints();
 
         $this->mapper->findBy($constraints);
@@ -173,8 +178,6 @@ class FinderTraitTest extends MapperTestCase
 
     public function testFindAllByConstructsWhereClausesWithAnds()
     {
-        $tableName = $this->mapper->getTableName();
-
         $constraints = $this->createSearchConstraints();
 
         $this->mapper->findAllBy($constraints);
@@ -411,7 +414,7 @@ class FinderTraitTest extends MapperTestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      */
     public function testFindAllByThrowsExceptionIfPageGivenButOrderNotGiven()
     {
@@ -493,6 +496,8 @@ class FinderTraitTest extends MapperTestCase
         $result = $this->mapper->findBy([]);
 
         $this->assertInstanceOf('Synapse\Entity\AbstractEntity', $result);
+
+        $this->assertEmpty($result->getChangedDbValues());
 
         $this->assertEquals(
             $mockResults,

--- a/tests/Test/Synapse/Mapper/UpdaterTraitTest.php
+++ b/tests/Test/Synapse/Mapper/UpdaterTraitTest.php
@@ -14,7 +14,7 @@ class UpdaterTraitTest extends MapperTestCase
     /**
      * @var AbstractMapper|UpdaterTrait
      */
-    private $mapper;
+    protected $mapper;
     /**
      * @var AbstractMapper|UpdaterTrait
      */


### PR DESCRIPTION
Will need to extend the hydrator to ensure entity is not dirty when hydrated.
This causes issues when using the new `patch()` method